### PR TITLE
SCO-124 clicking 'upload file' button before choosing a file disables the button

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
@@ -10,8 +10,10 @@ import org.apache.wicket.ResourceReference;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.IAjaxCallDecorator;
 import org.apache.wicket.ajax.calldecorator.AjaxPostprocessingCallDecorator;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.extensions.ajax.markup.html.IndicatingAjaxButton;
 import org.apache.wicket.feedback.FeedbackMessages;
+import org.apache.wicket.markup.html.IHeaderResponse;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -38,66 +40,76 @@ import org.sakaiproject.wicket.markup.html.form.CancelButton;
 public class UploadPage extends ConsoleBasePage implements ScormConstants {
 
 	private static final long serialVersionUID = 1L;
-	
-	private static ResourceReference PAGE_ICON = new ResourceReference(ConsoleBasePage.class, "res/table_add.png");
-	
-	private static Log log = LogFactory.getLog(FileUploadForm.class);
-	
+	private static final ResourceReference PAGE_ICON = new ResourceReference(ConsoleBasePage.class, "res/table_add.png");
+	private static final Log LOG = LogFactory.getLog(FileUploadForm.class);
+
 	// bjones86 - SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
 	private static final String SAK_PROP_SCORM_ENABLE_EMAIL = "scorm.enable.email";
 	@SpringBean( name = "org.sakaiproject.component.api.ServerConfigurationService" )
 	ServerConfigurationService serverConfigurationService;
-	
+
 	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormContentService")
 	ScormContentService contentService;
 	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormResourceService")
 	ScormResourceService resourceService;
-	
+
 	public UploadPage(PageParameters params) {
 		add(new FileUploadForm("uploadForm"));
 	}
-	
+
+	// SCO-124 - this is needed becasue we can't disable the button in Java and enable it in JavaScript, because Wicket will throw a runtime exception.
+	// So we have to both enable and disable the button via JavaScript.
+	@Override
+	public void renderHead( IHeaderResponse response )
+	{
+		super.renderHead( response );
+		String javascript = "document.getElementsByName( \"btnSubmit\" )[0].disabled = true;";
+		response.renderOnLoadJavascript( javascript );
+	}
+
 	@Override
 	protected ResourceReference getPageIconReference() {
 		return PAGE_ICON;
 	}
-	
+
 	public class FileUploadForm extends Form {
-		
+
 		private static final long serialVersionUID = 1L;
-		
 		private FileUploadField fileUploadField;
 		private boolean fileHidden = false;
 		private int priority = NotificationService.NOTI_NONE;
 		private boolean fileValidated = false;
 		private FileUpload fileInput;
-		
+
 		public FileUpload getFileInput() {
-        	return fileInput;
-        }
+			return fileInput;
+		}
 
 		public void setFileInput(FileUpload fileUpload) {
-        	this.fileInput = fileUpload;
-        }
+			this.fileInput = fileUpload;
+		}
 
 		public FileUploadForm(String id) {
 			super(id);
-			
+
 			IModel model = new CompoundPropertyModel(this);
 			this.setModel(model);
-			
+
 			// We need to establish the largest file allowed to be uploaded
 			setMaxSize(Bytes.megabytes(resourceService.getMaximumUploadFileSize()));
-			
+
 			// create a feedback panel, setMaxMessages not in this version
 			final Component feedbackPanel = new FeedbackPanel("feedback").setOutputMarkupPlaceholderTag(true);
 			//feedbackPanel.setMaxMessages( 5 );
 
 			setMultiPart(true);
-			
-			add(fileUploadField = new FileUploadField("fileInput"));
+
+			// Add JavaScript to enable the submit button only when there is a file selected (this cannot be done via Wicket/Java code)
+			fileUploadField = new FileUploadField( "fileInput" );
+			fileUploadField.add( new AttributeAppender( "onchange", new Model( "document.getElementsByName( \"btnSubmit\" )[0].disabled = this.value === '';" ), ";" ) );
+			add( fileUploadField );
 			add(new CheckBox("fileValidated"));
-			
+
 			// bjones86 - SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
 			@SuppressWarnings( { "unchecked", "rawtypes" } )
 			DropDownChoice emailNotificationDropDown = new DropDownChoice( "priority", 
@@ -109,27 +121,36 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 		
 						public Object getDisplayValue( Object object )
 						{
-			                switch( ((Integer) object) )
-			                {
-			                    case NotificationService.NOTI_NONE:
-				                    return getLocalizer().getString( "NotificationService.NOTI_NONE", UploadPage.this );
-			                    case NotificationService.NOTI_OPTIONAL:
-				                    return getLocalizer().getString( "NotificationService.NOTI_OPTIONAL", UploadPage.this );
-			                    case NotificationService.NOTI_REQUIRED:
-				                    return getLocalizer().getString( "NotificationService.NOTI_REQUIRED", UploadPage.this );
-		                    }
-			                
-			                return "";
-		                }
+							switch( ((Integer) object) )
+							{
+								case NotificationService.NOTI_NONE:
+								{
+									return getLocalizer().getString( "NotificationService.NOTI_NONE", UploadPage.this );
+								}
+								case NotificationService.NOTI_OPTIONAL:
+								{
+									return getLocalizer().getString( "NotificationService.NOTI_OPTIONAL", UploadPage.this );
+								}
+								case NotificationService.NOTI_REQUIRED:
+								{
+									return getLocalizer().getString( "NotificationService.NOTI_REQUIRED", UploadPage.this );
+								}
+							}
+
+							return "";
+						}
 		
 						public String getIdValue( Object object, int index )
 						{
 							if( object == null )
+							{
 								return "";
+							}
 							return object.toString();
-		                }
-					} );
-			
+						}
+					}
+			);
+
 			// bjones86 - SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
 			boolean enableEmail = serverConfigurationService.getBoolean( SAK_PROP_SCORM_ENABLE_EMAIL, true );
 			Label priorityLabel = new Label( "lblPriority", new ResourceModel( "upload.priority.label" ) );
@@ -142,19 +163,18 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 			}
 			add( priorityLabel );
 			add( emailNotificationDropDown );
-			
-			
+
 			// bjones86 - SCO-98 - disable buttons on submit, add spinner
 			final CancelButton btnCancel = new CancelButton( "btnCancel", PackageListPage.class );
 			IndicatingAjaxButton btnSubmit = new IndicatingAjaxButton( "btnSubmit", this )
 			{
 				private static final long serialVersionUID = 1L;
-				
+
 				@Override
 				protected void onError(AjaxRequestTarget target, Form<?> form ) {
 					FeedbackMessages feedbackMessages = form.getSession().getFeedbackMessages();
 					if (!feedbackMessages.isEmpty()) {
-						log.info("Errors uploading file." + feedbackMessages.toString());
+						LOG.info("Errors uploading file." + feedbackMessages.toString());
 					}
 					target.addComponent(feedbackPanel);
 				}
@@ -175,44 +195,44 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 				}
 				@Override
 				protected void onSubmit( AjaxRequestTarget target, Form<?> form )
-				{					
+				{
 					if( fileUploadField != null )
 					{
 						final FileUpload upload = fileUploadField.getFileUpload();
-				        if( upload != null )
-				        {
-				            try
-				            {
-				            	String resourceId = resourceService.putArchive( upload.getInputStream(), upload.getClientFileName(),
-				            			upload.getContentType(), isFileHidden(), getPriority() );
-				            	int status = contentService.storeAndValidate( resourceId, isFileValidated(), 
-				            			serverConfigurationService.getString( "scorm.zip.encoding", "UTF-8" ) );
-				            	
-				            	if( status == VALIDATION_SUCCESS )
-				            		setResponsePage( PackageListPage.class );
-				            	else
-				            	{
-					            	PageParameters params = new PageParameters();
-					            	params.add( "resourceId", resourceId );
-					            	params.put( "status", status );
-					            	setResponsePage( ConfirmPage.class, params );
-				            	}
-				            }
-				            catch( Exception e )
-				            {
-				            	UploadPage.this.warn( getLocalizer().getString( "upload.failed", UploadPage.this, new Model( e ) ) );
-				                log.error( "Failed to upload file", e );
-				            }
-				        }
+						if( upload != null )
+						{
+							try
+							{
+								String resourceId = resourceService.putArchive( upload.getInputStream(), upload.getClientFileName(),
+										upload.getContentType(), isFileHidden(), getPriority() );
+								int status = contentService.storeAndValidate( resourceId, isFileValidated(), 
+										serverConfigurationService.getString( "scorm.zip.encoding", "UTF-8" ) );
+
+								if( status == VALIDATION_SUCCESS )
+								{
+									setResponsePage( PackageListPage.class );
+								}
+								else
+								{
+									PageParameters params = new PageParameters();
+									params.add( "resourceId", resourceId );
+									params.put( "status", status );
+									setResponsePage( ConfirmPage.class, params );
+								}
+							}
+							catch( Exception e )
+							{
+								UploadPage.this.warn( getLocalizer().getString( "upload.failed", UploadPage.this, new Model( e ) ) );
+								LOG.error( "Failed to upload file", e );
+							}
+						}
 					}
 				}
 			};
 			add( btnCancel );
-			add( btnSubmit );			
+			add( btnSubmit );
 			add(feedbackPanel);
-
 		}
-
 
 		public boolean isFileHidden() {
 			return fileHidden;
@@ -231,14 +251,11 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 		}
 
 		public int getPriority() {
-        	return priority;
-        }
+			return priority;
+		}
 
 		public void setPriority(int priority) {
-        	this.priority = priority;
-        }
+			this.priority = priority;
+		}
 	}
-	
-	
-	
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-124

On the upload page, click the "Upload File" button before selecting a file. The result is that both buttons are disabled. The page is unusable in this state, and requires a refresh for the user to do anything.

The solution, is to disable the submit button by default on page load, and only enable it once the user has selected a file.
