### PR TITLE
SCO-126 implement table sorting on the various 'results' tables

### DIFF
--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/ActivitySummaryComparator.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/ActivitySummaryComparator.java
@@ -1,0 +1,61 @@
+package org.sakaiproject.scorm.model.api.comparator;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import org.sakaiproject.scorm.model.api.ActivitySummary;
+
+/**
+ * Custom comparator for ActivitySummary objects; used for sorting tables.
+ * @author bjones86
+ */
+public class ActivitySummaryComparator implements Comparator<ActivitySummary>, Serializable
+{
+    /**
+     * The available comparison types for LearnerExperience objects
+     */
+    public static enum CompType
+    {
+        Title, Score, CompletionStatus, SuccessStatus
+    }
+
+    public static final CompType DEFAULT_COMP = CompType.Title;
+    private CompType compType = DEFAULT_COMP;
+
+    /**
+     * Sets the comparison type the comparator will use. This determines which field of LearnerExperience is used for comparisons.
+     * @param value the comparison type
+     */
+    public void setCompType( CompType value )
+    {
+        if( value != null )
+        {
+            compType = value;
+        }
+    }
+
+    @Override
+    public int compare( ActivitySummary as1, ActivitySummary as2 )
+    {
+        switch( compType )
+        {
+            case Title:
+            {
+                return as1.getTitle().compareTo( as2.getTitle() );
+            }
+            case Score:
+            {
+                return Double.compare( as1.getScaled(), as2.getScaled() );
+            }
+            case CompletionStatus:
+            {
+                return as1.getCompletionStatus().compareTo( as2.getCompletionStatus() );
+            }
+            case SuccessStatus:
+            {
+                return as1.getSuccessStatus().compareTo( as2.getSuccessStatus() );
+            }
+        }
+
+        return 0;
+    }
+}

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/InteractionComparator.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/InteractionComparator.java
@@ -1,0 +1,61 @@
+package org.sakaiproject.scorm.model.api.comparator;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import org.sakaiproject.scorm.model.api.Interaction;
+
+/**
+ * Custom comparator for Interaction objects; used for sorting data tables;
+ * @author bjones86
+ */
+public class InteractionComparator implements Comparator<Interaction>, Serializable
+{
+    /**
+     * The available comparison types for LearnerExperience objects
+     */
+    public static enum CompType
+    {
+        InteractionID, Description, Type, Result
+    }
+
+    public static final CompType DEFAULT_COMP = CompType.InteractionID;
+    private CompType compType = DEFAULT_COMP;
+
+    /**
+     * Sets the comparison type the comparator will use. This determines which field of LearnerExperience is used for comparisons.
+     * @param value the comparison type
+     */
+    public void setCompType( CompType value )
+    {
+        if( value != null )
+        {
+            compType = value;
+        }
+    }
+
+    @Override
+    public int compare( Interaction int1, Interaction int2 )
+    {
+        switch( compType )
+        {
+            case InteractionID:
+            {
+                return int1.getInteractionId().compareTo( int2.getInteractionId() );
+            }
+            case Description:
+            {
+                return int1.getDescription().compareTo( int2.getDescription() );
+            }
+            case Type:
+            {
+                return int1.getType().compareTo( int2.getType() );
+            }
+            case Result:
+            {
+                return int1.getResult().compareTo( int2.getResult() );
+            }
+        }
+
+        return 0;
+    }
+}

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
@@ -1,0 +1,63 @@
+package org.sakaiproject.scorm.model.api.comparator;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import org.apache.commons.lang.ObjectUtils;
+import org.sakaiproject.scorm.model.api.LearnerExperience;
+
+/**
+ * Custom comparator for LearnerExperience objects; used for sorting data tables.
+ * @author bjones86
+ */
+public class LearnerExperienceComparator implements Comparator<LearnerExperience>, Serializable
+{
+    /**
+     * The available comparison types for LearnerExperience objects
+     */
+    public static enum CompType
+    {
+        Learner, AttemptDate, Status, NumberOfAttempts
+    }
+
+    public static final CompType DEFAULT_COMP = CompType.Learner;
+    private CompType compType = DEFAULT_COMP;
+
+    /**
+     * Sets the comparison type the comparator will use. This determines which field of LearnerExperience is used for comparisons.
+     * @param value the comparison type
+     */
+    public void setCompType( CompType value )
+    {
+        if( value != null )
+        {
+            compType = value;
+        }
+    }
+
+    @Override
+    public int compare( LearnerExperience le1, LearnerExperience le2 )
+    {
+        // Perform different comparison depending on which comparison type has been selected
+        switch( compType )
+        {
+            case Learner:
+            {
+                return le1.getLearnerName().compareTo( le2.getLearnerName() );
+            }
+            case AttemptDate:
+            {
+                return ObjectUtils.compare( le1.getLastAttemptDate(), le2.getLastAttemptDate() );
+            }
+            case Status:
+            {
+                return Integer.compare( le1.getStatus(), le2.getStatus() );
+            }
+            case NumberOfAttempts:
+            {
+                return Integer.compare( le1.getNumberOfAttempts(), le2.getNumberOfAttempts() );
+            }
+        }
+
+        return 0;
+    }
+}

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
@@ -61,45 +61,44 @@ public class PackageListPage extends ConsoleBasePage implements ScormConstants {
 	private static final long serialVersionUID = 1L;
 
 	@SuppressWarnings("unused")
-	private static Log log = LogFactory.getLog(PackageListPage.class);
-	
-	private static ResourceReference PAGE_ICON = new ResourceReference(PackageListPage.class, "res/table.png");
-	private static final ResourceReference deleteIconReference = new ResourceReference(PackageListPage.class, "res/delete.png");
-	
+	private static final Log LOG = LogFactory.getLog(PackageListPage.class);
+
+	private static final ResourceReference PAGE_ICON = new ResourceReference(PackageListPage.class, "res/table.png");
+	private static final ResourceReference DELETE_ICON = new ResourceReference(PackageListPage.class, "res/delete.png");
+
 	@SpringBean
 	LearningManagementSystem lms;
 	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormContentService")
 	ScormContentService contentService;
-	
+
 	public PackageListPage(PageParameters params) {
-		
+
 		List<ContentPackage> contentPackages = contentService.getContentPackages();
-		
+
 		final String context = lms.currentContext();
 		final boolean canConfigure = lms.canConfigure(context);
 		final boolean canGrade = lms.canGrade(context);
-        final boolean canViewResults = lms.canViewResults(context);
-//		final boolean canLaunch = lms.canLaunch(context);
+		final boolean canViewResults = lms.canViewResults(context);
 		final boolean canDelete = lms.canDelete(context);
-		
+
 		List<IColumn<ContentPackage>> columns = new LinkedList<IColumn<ContentPackage>>();
 
 		ActionColumn actionColumn = new ActionColumn(new StringResourceModel("column.header.content.package.name", this, null), "title", "title");
-			
+
 		String[] paramPropertyExpressions = {"contentPackageId", "resourceId", "title"};
-		
+
 		Action launchAction = new Action("title", PlayerPage.class, paramPropertyExpressions){
 			private static final long serialVersionUID = 1L;
 			@Override
 			public Component newLink(String id, Object bean) {
-				IModel<String> labelModel = null;
+				IModel<String> labelModel;
 				if (displayModel != null) {
 					labelModel = displayModel;
-		 		} else {
-		 			String labelValue = String.valueOf(PropertyResolver.getValue(labelPropertyExpression, bean));
-		 			labelModel = new Model<String>(labelValue);
-		 		}
-				
+				} else {
+					String labelValue = String.valueOf(PropertyResolver.getValue(labelPropertyExpression, bean));
+					labelModel = new Model<String>(labelValue);
+				}
+
 				PageParameters params = buildPageParameters(paramPropertyExpressions, bean);
 				Link link = new BookmarkablePageLabeledLink(id, labelModel, pageClass, params);
 
@@ -107,52 +106,54 @@ public class PackageListPage extends ConsoleBasePage implements ScormConstants {
 					PopupSettings popupSettings = new PopupSettings(PageMap.forName(popupWindowName), PopupSettings.RESIZABLE);
 					popupSettings.setWidth(1020);
 					popupSettings.setHeight(740);
-					
+
 					popupSettings.setWindowName(popupWindowName);
-					
-		 			link.setPopupSettings(popupSettings);
+
+					link.setPopupSettings(popupSettings);
 				}
-				
+
 				link.setEnabled(isEnabled(bean) && lms.canLaunch((ContentPackage)bean));
 				link.setVisible(isVisible(bean));
-					
-		 		return link;
+
+				return link;
 			}
-			
 		};
+
 		actionColumn.addAction(launchAction);
-		
+
 		if (lms.canLaunchNewWindow()) {
 			launchAction.setPopupWindowName("ScormPlayer");
 		}
 
 		if (canConfigure)
+		{
 			actionColumn.addAction(new Action(new ResourceModel("column.action.edit.label"), PackageConfigurationPage.class, paramPropertyExpressions));
-			
+		}
 		if (canGrade) {
 			actionColumn.addAction(new Action(new StringResourceModel("column.action.grade.label", this, null), ResultsListPage.class, paramPropertyExpressions));
 		}
 		else if (canViewResults) {
-            actionColumn.addAction(new Action(new StringResourceModel("column.action.grade.label", this, null), LearnerResultsPage.class, paramPropertyExpressions));
-        }
-		
+			actionColumn.addAction(new Action(new StringResourceModel("column.action.grade.label", this, null), LearnerResultsPage.class, paramPropertyExpressions));
+		}
+
 		columns.add(actionColumn);
 
 		columns.add(new StatusColumn(new StringResourceModel("column.header.status", this, null), "status"));
-		
+
 		columns.add(new DecoratedDatePropertyColumn(new StringResourceModel("column.header.releaseOn", this, null), "releaseOn", "releaseOn"));
 
 		columns.add(new DecoratedDatePropertyColumn(new StringResourceModel("column.header.dueOn", this, null), "dueOn", "dueOn"));
-		
+
 		if (canDelete)
-			columns.add(new ImageLinkColumn(new Model("Remove"), PackageRemovePage.class, paramPropertyExpressions, deleteIconReference));
+		{
+			columns.add(new ImageLinkColumn(new Model("Remove"), PackageRemovePage.class, paramPropertyExpressions, DELETE_ICON, "delete"));
+		}
 
 		BasicDataTable table = new BasicDataTable("cpTable", columns, contentPackages);
-		
+
 		add(table);
-	}	
-	
-	
+	}
+
 	public class StatusColumn extends AbstractColumn<ContentPackage> {
 
 		private static final long serialVersionUID = 1L;
@@ -164,17 +165,17 @@ public class PackageListPage extends ConsoleBasePage implements ScormConstants {
 		public void populateItem(Item<ICellPopulator<ContentPackage>> item, String componentId, IModel<ContentPackage> model) {
 			item.add(new Label(componentId, createLabelModel(model)));
 		}
-		
+
 		protected IModel<String> createLabelModel(IModel<ContentPackage> embeddedModel)
 		{
 			String resourceId = "status.unknown";
 			Object target = embeddedModel.getObject();
-			
+
 			if (target instanceof ContentPackage) {
 				ContentPackage contentPackage = (ContentPackage)target;
-				
+
 				int status = contentService.getContentPackageStatus(contentPackage);
-				
+
 				switch (status) {
 				case CONTENT_PACKAGE_STATUS_OPEN:
 					resourceId = "status.open";
@@ -190,17 +191,14 @@ public class PackageListPage extends ConsoleBasePage implements ScormConstants {
 					break;
 				}
 			}
-			
+
 			return new ResourceModel(resourceId);
 		}
-
-
 	}
-	
+
 	@Override
 	protected ResourceReference getPageIconReference() {
 		return PAGE_ICON;
 	}
-	
-	
+
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
@@ -49,31 +49,30 @@ public class InteractionResultsPage extends BaseResultsPage {
 
 	private static final long serialVersionUID = 1L;
 
-	private static ResourceReference PAGE_ICON = new ResourceReference(InteractionResultsPage.class, "res/report_magnify.png");
-	
+	private static final ResourceReference PAGE_ICON = new ResourceReference(InteractionResultsPage.class, "res/report_magnify.png");
+
 	public InteractionResultsPage(PageParameters pageParams) {
 		super(pageParams);
 	}
-	
+
 	@Override
 	protected ResourceReference getPageIconReference() {
 		return PAGE_ICON;
 	}
-	
+
 	@Override
-	protected void initializePage(ContentPackage contentPackage,
-			Learner learner, long attemptNumber, PageParameters pageParams) {
+	protected void initializePage(ContentPackage contentPackage, Learner learner, long attemptNumber, PageParameters pageParams) {
 		String scoId = pageParams.getString("scoId");
-		
+
 		PageParameters uberuberparentParams = new PageParameters();
 		uberuberparentParams.put("contentPackageId", contentPackage.getContentPackageId());
-		
+
 		PageParameters parentParams = new PageParameters();
 		parentParams.put("contentPackageId", contentPackage.getContentPackageId());
 		parentParams.put("learnerId", learner.getId());
 		parentParams.put("attemptNumber", attemptNumber);
-		
-		// bjones86 - SCO-94 - deny users who do not have scorm.view.results permission
+
+		// SCO-94 - deny users who do not have scorm.view.results permission
 		String context = lms.currentContext();
 		boolean canViewResults = lms.canViewResults( context );
 		Label heading = new Label( "heading3", new ResourceModel( "page.heading.notAllowed" ) );
@@ -86,27 +85,27 @@ public class InteractionResultsPage extends BaseResultsPage {
 		}
 		else
 		{
-			// bjones86 - SCO-94
+			// SCO-94
 			heading.setVisibilityAllowed( false );
-		
+
 			String interactionId = pageParams.getString("interactionId");
-			
+
 			Interaction interaction = resultService.getInteraction(contentPackage.getContentPackageId(), learner.getId(), attemptNumber, scoId, interactionId);
-			
+
 			add(new InteractionPanel("interactionPanel", interaction));
-			
+
 			IModel breadcrumbModel = new StringResourceModel("uberuberparent.breadcrumb", this, new Model(contentPackage));
 			addBreadcrumb(breadcrumbModel, ResultsListPage.class, uberuberparentParams, true);	
 			addBreadcrumb(new Model(learner.getDisplayName()), LearnerResultsPage.class, parentParams, true);
 			addBreadcrumb(new Model(interaction.getActivityTitle()), ScoResultsPage.class, pageParams, true);
 			addBreadcrumb(new Model(interaction.getInteractionId()), InteractionResultsPage.class, pageParams, false);
-			
+
 			List<Objective> objectives = interaction.getObjectives();
 			ObjectiveProvider dataProvider = new ObjectiveProvider(objectives);
 			dataProvider.setTableTitle("Objectives");
 			EnhancedDataPresenter presenter = new EnhancedDataPresenter("objectivePresenter", getColumns(), dataProvider);
-			add(presenter);	
-			
+			add(presenter);
+
 			presenter.setVisible(objectives != null && objectives.size() > 0);
 		}
 	}
@@ -114,45 +113,44 @@ public class InteractionResultsPage extends BaseResultsPage {
 	@Override
 	protected Link newPreviousLink(String previousId, PageParameters pageParams) {
 		PageParameters prevParams = new PageParameters();
-		
+
 		long contentPackageId = pageParams.getLong("contentPackageId");
 		String learnerId = pageParams.getString("learnerId");
 		long attemptNumber = pageParams.getLong("attemptNumber");
 		String scoId = pageParams.getString("scoId");
-		
+
 		prevParams.put("contentPackageId", contentPackageId);
 		prevParams.put("learnerId", learnerId);
 		prevParams.put("attemptNumber", attemptNumber);
 		prevParams.put("scoId", scoId);
 		prevParams.put("interactionId", previousId);
-		
+
 		Link link = new BookmarkablePageLabeledLink("previousLink", new ResourceModel("previous.link.label"), InteractionResultsPage.class, prevParams);
 		link.setVisible(StringUtils.isNotBlank(previousId));
 		return link;
 	}
-	
+
 	@Override
 	protected Link newNextLink(String nextId, PageParameters pageParams) {
 		PageParameters nextParams = new PageParameters();
-		
+
 		long contentPackageId = pageParams.getLong("contentPackageId");
 		String learnerId = pageParams.getString("learnerId");
 		long attemptNumber = pageParams.getLong("attemptNumber");
 		String scoId = pageParams.getString("scoId");
-		
+
 		nextParams.put("contentPackageId", contentPackageId);
 		nextParams.put("learnerId", learnerId);
 		nextParams.put("attemptNumber", attemptNumber);
 		nextParams.put("scoId", scoId);
 		nextParams.put("interactionId", nextId);
-		
+
 		Link link = new BookmarkablePageLabeledLink("nextLink", new ResourceModel("next.link.label"), InteractionResultsPage.class, nextParams);
 
 		link.setVisible(StringUtils.isNotBlank(nextId));
 		return link;
 	}
-	
-	
+
 	@Override
 	protected BookmarkablePageLabeledLink newAttemptNumberLink(long i, PageParameters params) {
 		return new BookmarkablePageLabeledLink("attemptNumberLink", new Model("" + i), InteractionResultsPage.class, params);
@@ -163,15 +161,14 @@ public class InteractionResultsPage extends BaseResultsPage {
 		IModel descriptionHeader = new ResourceModel("column.header.description");
 		IModel completionStatusHeader = new ResourceModel("column.header.completion.status");
 		IModel successStatusHeader = new ResourceModel("column.header.success.status");
-		
+
 		List<IColumn> columns = new LinkedList<IColumn>();
 
 		columns.add(new PropertyColumn(idHeader, "id", "id"));
 		columns.add(new PropertyColumn(descriptionHeader, "description", "description"));
 		columns.add(new PropertyColumn(completionStatusHeader, "completionStatus", "completionStatus"));
 		columns.add(new PropertyColumn(successStatusHeader, "successStatus", "successStatus"));
-		
+
 		return columns;
 	}
-	
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
@@ -50,24 +50,23 @@ public class LearnerResultsPage extends BaseResultsPage {
 
 	private static final long serialVersionUID = 1L;
 
-	private static ResourceReference PAGE_ICON = new ResourceReference(LearnerResultsPage.class, "res/report_user.png");
+	private static final ResourceReference PAGE_ICON = new ResourceReference(LearnerResultsPage.class, "res/report_user.png");
 
 	public LearnerResultsPage(PageParameters pageParams) {
-		super(pageParams);		
+		super(pageParams);
 	}
 
-	
 	@Override
 	protected void initializePage(ContentPackage contentPackage, Learner learner, long attemptNumber, PageParameters pageParams) {
 		PageParameters uberparentParams = new PageParameters();
 		uberparentParams.put("contentPackageId", contentPackage.getContentPackageId());
-		
+
 		PageParameters parentParams = new PageParameters();
 		parentParams.put("contentPackageId", contentPackage.getContentPackageId());
 		parentParams.put("learnerId", learner.getId());
 		parentParams.put("attemptNumber", attemptNumber);
-		
-		// bjones86 - SCO-94 - deny users who do not have scorm.view.results permission
+
+		// SCO-94 - deny users who do not have scorm.view.results permission
 		String context = lms.currentContext();
 		boolean canViewResults = lms.canViewResults( context );
 		Label heading = new Label( "heading1", new ResourceModel( "page.heading.notAllowed" ) );
@@ -79,9 +78,9 @@ public class LearnerResultsPage extends BaseResultsPage {
 		}
 		else
 		{
-			// bjones86 - SCO-94
+			// SCO-94
 			heading.setVisibilityAllowed( false );
-		
+
 			IModel breadcrumbModel = new StringResourceModel("parent.breadcrumb", this, new Model(contentPackage));
 			// MvH
 			if (isSinglePackageTool()) {
@@ -101,13 +100,13 @@ public class LearnerResultsPage extends BaseResultsPage {
 				}
 			}
 			addBreadcrumb(new Model(learner.getDisplayName()), LearnerResultsPage.class, parentParams, false);
-			
+
 			List<ActivitySummary> summaries = resultService.getActivitySummaries(contentPackage.getContentPackageId(), learner.getId(), attemptNumber);
 			SummaryProvider dataProvider = new SummaryProvider(summaries);
 			dataProvider.setTableTitle(getLocalizer().getString("table.title", this));
 			EnhancedDataPresenter presenter = new EnhancedDataPresenter("summaryPresenter", getColumns(), dataProvider);
 			add(presenter);
-			
+
 			presenter.setVisible(summaries != null && summaries.size() > 0);
 		}
 	}
@@ -115,59 +114,23 @@ public class LearnerResultsPage extends BaseResultsPage {
 	@Override
 	protected Link newPreviousLink(String previousId, PageParameters pageParams) {
 		PageParameters prevParams = new PageParameters();
-		
+
 		long contentPackageId = pageParams.getLong("contentPackageId");
-		
+
 		prevParams.put("contentPackageId", contentPackageId);
 		prevParams.put("learnerId", previousId);
-		
+
 		Link link = new BookmarkablePageLabeledLink("previousLink", new ResourceModel("previous.link.label"), LearnerResultsPage.class, prevParams);
 		link.setVisible(StringUtils.isNotEmpty(previousId));
 		return link;
-		
-		/*PageParameters prevParams = new PageParameters();
-		
-		long contentPackageId = pageParams.getLong("contentPackageId");
-		String learnerId = pageParams.getString("learnerId");
-		
-		prevParams.put("contentPackageId", contentPackageId);
-		
-		String previousLearnerIds = pageParams.getString("previousLearnerIds");
-		String nextLearnerIds = pageParams.getString("nextLearnerIds");
-		
-		if (previousLearnerIds == null)
-			previousLearnerIds = "";
-		
-		boolean showPrevious = false;
-
-		if (StringUtils.isNotEmpty(previousLearnerIds)) {
-			int indexOf = previousLearnerIds.indexOf(',');
-			String currentLearnerId = previousLearnerIds.substring(0, indexOf);
-			
-			prevParams.put("learnerId", currentLearnerId);
-			
-			if (indexOf + 1 < previousLearnerIds.length()) 
-				prevParams.put("previousLearnerIds", previousLearnerIds.substring(indexOf+1));
-			
-			String nextIds = new StringBuilder().append(learnerId).append(",").append(nextLearnerIds).toString();
-		
-			prevParams.put("nextLearnerIds", nextIds);
-			showPrevious = true;
-		}
-		
-		Link link = new BookmarkablePageLabeledLink("previousLink", new ResourceModel("previous.link.label"), LearnerResultsPage.class, prevParams);
-	
-		link.setVisible(showPrevious);
-		
-		return link;*/
 	}
-	
+
 	@Override
 	protected Link newNextLink(String nextId, PageParameters pageParams) {
 		PageParameters nextParams = new PageParameters();
-		
+
 		long contentPackageId = pageParams.getLong("contentPackageId");
-		
+
 		nextParams.put("contentPackageId", contentPackageId);
 		nextParams.put("learnerId", nextId);
 
@@ -175,81 +138,38 @@ public class LearnerResultsPage extends BaseResultsPage {
 
 		link.setVisible(StringUtils.isNotBlank(nextId));
 		return link;
-		
-		/*PageParameters nextParams = new PageParameters();
-		
-		long contentPackageId = pageParams.getLong("contentPackageId");
-		String learnerId = pageParams.getString("learnerId");
-		
-		nextParams.put("contentPackageId", contentPackageId);
-		
-		String previousLearnerIds = pageParams.getString("previousLearnerIds");
-		String nextLearnerIds = pageParams.getString("nextLearnerIds");
-		
-		if (previousLearnerIds == null)
-			previousLearnerIds = "";
-		if (nextLearnerIds == null)
-			nextLearnerIds = "";
-
-		boolean showNext = false;
-			
-		if (StringUtils.isNotBlank(nextLearnerIds)) {
-			int indexOf = nextLearnerIds.indexOf(',');
-			String currentLearnerId = nextLearnerIds.substring(0, indexOf);
-			
-			nextParams.put("learnerId", currentLearnerId);
-			
-			if (indexOf + 1 < nextLearnerIds.length())
-				nextParams.put("nextLearnerIds", nextLearnerIds.substring(indexOf + 1));
-			
-			String prevIds = new StringBuilder().append(learnerId).append(",").append(previousLearnerIds).toString();
-			
-			nextParams.put("previousLearnerIds", prevIds);
-			showNext = true;
-		}
-		
-		
-		Link link = new BookmarkablePageLabeledLink("nextLink", new ResourceModel("next.link.label"), LearnerResultsPage.class, nextParams);
-	
-		link.setVisible(showNext);
-		
-		return link;*/
 	}
-	
-	
+
 	@Override
 	protected BookmarkablePageLabeledLink newAttemptNumberLink(long i, PageParameters params) {
 		return new BookmarkablePageLabeledLink("attemptNumberLink", new Model("" + i), LearnerResultsPage.class, params);
 	}
-	
+
 	@Override
 	protected ResourceReference getPageIconReference() {
 		return PAGE_ICON;
 	}
-	
+
 	private List<IColumn> getColumns() {
 		IModel titleHeader = new ResourceModel("column.header.title");
 		IModel scoreHeader = new ResourceModel("column.header.score");
 		IModel completedHeader = new ResourceModel("column.header.completed");
 		IModel successHeader = new ResourceModel("column.header.success");
-		
-		
+
 		List<IColumn> columns = new LinkedList<IColumn>();
-		
+
 		String[] paramPropertyExpressions = {"contentPackageId", "learnerId", "scoId", "attemptNumber"};
-		
+
 		ActionColumn actionColumn = new ActionColumn(titleHeader, "title", "title");
 		actionColumn.addAction(new Action("title", ScoResultsPage.class, paramPropertyExpressions));
 		columns.add(actionColumn);
-		
+
 		columns.add(new PercentageColumn(scoreHeader, "scaled", "scaled"));
-		
+
 		columns.add(new PropertyColumn(completedHeader, "completionStatus", "completionStatus"));
-		
+
 		columns.add(new PropertyColumn(successHeader, "successStatus", "successStatus"));
-				
+
 		return columns;
 	}
-	
-	
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.java
@@ -36,14 +36,12 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.model.StringResourceModel;
-import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.sakaiproject.scorm.model.api.ActivityReport;
 import org.sakaiproject.scorm.model.api.ContentPackage;
 import org.sakaiproject.scorm.model.api.Interaction;
 import org.sakaiproject.scorm.model.api.Learner;
 import org.sakaiproject.scorm.model.api.Progress;
 import org.sakaiproject.scorm.model.api.Score;
-import org.sakaiproject.scorm.service.api.ScormResultService;
 import org.sakaiproject.scorm.ui.reporting.components.InteractionPanel;
 import org.sakaiproject.scorm.ui.reporting.components.ProgressPanel;
 import org.sakaiproject.scorm.ui.reporting.components.ScorePanel;
@@ -59,23 +57,18 @@ public class ScoResultsPage extends BaseResultsPage {
 
 	private static final long serialVersionUID = 1L;
 
-	private static ResourceReference PAGE_ICON = new ResourceReference(ScoResultsPage.class, "res/report_picture.png");
-	
-	private static ResourceReference BLANK_ICON = new ResourceReference(InteractionPanel.class, "res/brick.png");
-	private static ResourceReference CORRECT_ICON = new ResourceReference(InteractionPanel.class, "res/tick.png");
-	private static ResourceReference INCORRECT_ICON = new ResourceReference(InteractionPanel.class, "res/cross.png");
-	private static ResourceReference UNANTICIPATED_ICON = new ResourceReference(InteractionPanel.class, "res/exclamation.png");
-	private static ResourceReference NEUTRAL_ICON = new ResourceReference(InteractionPanel.class, "res/page_white_text.png");
+	private static final ResourceReference PAGE_ICON = new ResourceReference(ScoResultsPage.class, "res/report_picture.png");
 
-	
-	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormResultService")
-	ScormResultService resultService;
-	
+	private static final ResourceReference BLANK_ICON = new ResourceReference(InteractionPanel.class, "res/brick.png");
+	private static final ResourceReference CORRECT_ICON = new ResourceReference(InteractionPanel.class, "res/tick.png");
+	private static final ResourceReference INCORRECT_ICON = new ResourceReference(InteractionPanel.class, "res/cross.png");
+	private static final ResourceReference UNANTICIPATED_ICON = new ResourceReference(InteractionPanel.class, "res/exclamation.png");
+	private static final ResourceReference NEUTRAL_ICON = new ResourceReference(InteractionPanel.class, "res/page_white_text.png");
+
 	public ScoResultsPage(PageParameters pageParams) {
 		super(pageParams);
-		
 	}
-	
+
 	@Override
 	protected ResourceReference getPageIconReference() {
 		return PAGE_ICON;
@@ -84,16 +77,16 @@ public class ScoResultsPage extends BaseResultsPage {
 	@Override
 	protected void initializePage(ContentPackage contentPackage, Learner learner, long attemptNumber, PageParameters pageParams) {
 		String scoId = pageParams.getString("scoId");
-		
+
 		PageParameters uberparentParams = new PageParameters();
 		uberparentParams.put("contentPackageId", contentPackage.getContentPackageId());
-		
+
 		PageParameters parentParams = new PageParameters();
 		parentParams.put("contentPackageId", contentPackage.getContentPackageId());
 		parentParams.put("learnerId", learner.getId());
 		parentParams.put("attemptNumber", attemptNumber);
-		
-		// bjones86 - SCO-94 - deny users who do not have scorm.view.results permission
+
+		// SCO-94 - deny users who do not have scorm.view.results permission
 		String context = lms.currentContext();
 		boolean canViewResults = lms.canViewResults( context );
 		Label heading = new Label( "heading2", new ResourceModel( "page.heading.notAllowed" ) );
@@ -107,58 +100,57 @@ public class ScoResultsPage extends BaseResultsPage {
 		}
 		else
 		{
-			// bjones86 - SCO-94
+			// SCO-94
 			heading.setVisibilityAllowed( false );
-		
+
 			IModel breadcrumbModel = new StringResourceModel("uberparent.breadcrumb", this, new Model(contentPackage));
 			addBreadcrumb(breadcrumbModel, ResultsListPage.class, uberparentParams, true);	
 			addBreadcrumb(new Model(learner.getDisplayName()), LearnerResultsPage.class, parentParams, true);
-	
+
 			ActivityReport report = resultService.getActivityReport(contentPackage.getContentPackageId(), learner.getId(), attemptNumber, scoId);
-			
-			List<Interaction> interactions = null;
-			
+
+			List<Interaction> interactions;
+
 			if (report != null) {
 				addBreadcrumb(new Model(report.getTitle()), ScoResultsPage.class, pageParams, false);
-				
+
 				add(new ScorePanel("scorePanel", report.getScore()));
 				add(new ProgressPanel("progressPanel", report.getProgress()));
-	
+
 				interactions = report.getInteractions();
 			}
 			
 			else {
 				addBreadcrumb(new Model("[no module]"), ScoResultsPage.class, pageParams, false);
-				
+
 				add(new ScorePanel("scorePanel", new Score()));
 				add(new ProgressPanel("progressPanel", new Progress()));
-				
+
 				interactions = new ArrayList<Interaction>();
-				
 			}
-			
+
 			InteractionProvider dataProvider = new InteractionProvider(interactions);
 			dataProvider.setTableTitle("Interactions");
 			EnhancedDataPresenter presenter = new EnhancedDataPresenter("interactionPresenter", getColumns(), dataProvider);
 			add(presenter);
-			
+
 			presenter.setVisible(interactions != null && interactions.size() > 0);
 		}
 	}
-	
+
 	@Override
 	protected Link newPreviousLink(String previousId, PageParameters pageParams) {
 		PageParameters prevParams = new PageParameters();
-		
+
 		long contentPackageId = pageParams.getLong("contentPackageId");
 		String learnerId = pageParams.getString("learnerId");
 		long attemptNumber = pageParams.getLong("attemptNumber");
-		
+
 		prevParams.put("contentPackageId", contentPackageId);
 		prevParams.put("learnerId", learnerId);
 		prevParams.put("attemptNumber", attemptNumber);
 		prevParams.put("scoId", previousId);
-		
+
 		Link link = new BookmarkablePageLabeledLink("previousLink", new ResourceModel("previous.link.label"), ScoResultsPage.class, prevParams);
 		link.setVisible(StringUtils.isNotBlank(previousId));
 		return link;
@@ -166,78 +158,60 @@ public class ScoResultsPage extends BaseResultsPage {
 
 	@Override
 	protected boolean attemptExists(long attemptId, String scoId, String learnerId, long contentPackageId) {
-	    return resultService.existsActivityReport(contentPackageId, learnerId, attemptId, scoId);
-    }
-	
+		return resultService.existsActivityReport(contentPackageId, learnerId, attemptId, scoId);
+	}
+
 	@Override
 	protected boolean isPreviousLinkVisible(String[] siblingIds) {
 		return StringUtils.isNotEmpty(siblingIds[0]);
 	}
-	
+
 	@Override
 	protected Link newNextLink(String nextId, PageParameters pageParams) {
 		PageParameters nextParams = new PageParameters();
-		
+
 		long contentPackageId = pageParams.getLong("contentPackageId");
 		String learnerId = pageParams.getString("learnerId");
 		long attemptNumber = pageParams.getLong("attemptNumber");
-		
+
 		nextParams.put("contentPackageId", contentPackageId);
 		nextParams.put("learnerId", learnerId);
 		nextParams.put("attemptNumber", attemptNumber);
 		nextParams.put("scoId", nextId);
-		
+
 		Link link = new BookmarkablePageLabeledLink("nextLink", new ResourceModel("next.link.label"), ScoResultsPage.class, nextParams);
 
 		link.setVisible(StringUtils.isNotBlank(nextId));
 		return link;
 	}
-	
+
 	@Override
 	protected boolean isNextLinkVisible(String[] siblingIds) {
 		return siblingIds[1] != null && !siblingIds[1].equals("");
 	}
-	
+
 	@Override
 	protected BookmarkablePageLabeledLink newAttemptNumberLink(long i, PageParameters params) {
 		return new BookmarkablePageLabeledLink("attemptNumberLink", new Model("" + i), ScoResultsPage.class, params);
 	}
-	
+
 	private List<IColumn> getColumns() {
 		IModel idHeader = new ResourceModel("column.header.id");
 		IModel descriptionHeader = new ResourceModel("column.header.description");
 		IModel typeHeader = new ResourceModel("column.header.type");
 		IModel resultHeader = new ResourceModel("column.header.result");
-		
+
 		List<IColumn> columns = new LinkedList<IColumn>();
 
 		String[] paramPropertyExpressions = {"contentPackageId", "learnerId", "scoId", "attemptNumber", "interactionId"};
-		
+
 		ActionColumn actionColumn = new ActionColumn(idHeader, "interactionId", "interactionId");
 		actionColumn.addAction(new Action("interactionId", InteractionResultsPage.class, paramPropertyExpressions));
 		columns.add(actionColumn);
 		columns.add(new PropertyColumn(descriptionHeader, "description", "description"));
 		columns.add(new TypePropertyColumn(typeHeader, "type", "type"));
-		columns.add(new IconPropertyColumn(resultHeader, InteractionResultsPage.class, paramPropertyExpressions, "result"));
-		
-		/*ResourceReference resultIconReference = BLANK_ICON;
-		String result = interaction.getResult();
-		if (result != null) {
-			if (result.equalsIgnoreCase("correct"))
-				resultIconReference = CORRECT_ICON;
-			else if (result.equalsIgnoreCase("incorrect"))
-				resultIconReference = INCORRECT_ICON;
-			else if (result.equalsIgnoreCase("neutral")) {
-				resultIconReference = NEUTRAL_ICON;
-				isNeutral = true;
-			} else if (result.equalsIgnoreCase("unanticipated"))
-				resultIconReference = UNANTICIPATED_ICON;
-			else
-				showIcon = false;
-		} else
-			showIcon = false;
-		*/
-		
+		columns.add(new IconPropertyColumn(resultHeader, InteractionResultsPage.class, paramPropertyExpressions, "result", "result"));
+
 		return columns;
 	}
 
@@ -245,37 +219,42 @@ public class ScoResultsPage extends BaseResultsPage {
 
 		private static final long serialVersionUID = 1L;
 
-		public IconPropertyColumn(IModel displayModel, Class<?> pageClass,
-				String[] paramPropertyExpressions, String iconProperty) {
-			super(displayModel, pageClass, paramPropertyExpressions, iconProperty);
+		public IconPropertyColumn(IModel displayModel, Class<?> pageClass, String[] paramPropertyExpressions, String iconProperty, String sortProperty) {
+			super(displayModel, pageClass, paramPropertyExpressions, iconProperty, sortProperty);
 		}
-		
+
 		@Override
 		protected ResourceReference getIconPropertyReference(String iconPropertyValue) {
 			ResourceReference resultIconReference = BLANK_ICON;
 
 			if (iconPropertyValue != null) {
 				if (iconPropertyValue.equalsIgnoreCase("correct"))
+				{
 					resultIconReference = CORRECT_ICON;
+				}
 				else if (iconPropertyValue.equalsIgnoreCase("incorrect"))
+				{
 					resultIconReference = INCORRECT_ICON;
+				}
 				else if (iconPropertyValue.equalsIgnoreCase("neutral")) 
+				{
 					resultIconReference = NEUTRAL_ICON;
+				}
 				else if (iconPropertyValue.equalsIgnoreCase("unanticipated"))
+				{
 					resultIconReference = UNANTICIPATED_ICON;
+				}
 			}
-			
+
 			return resultIconReference;
 		}
-		
 	}
-	
+
 	public class TypePropertyColumn extends DecoratedPropertyColumn {
 
 		private static final long serialVersionUID = 1L;
 
-		public TypePropertyColumn(IModel displayModel, String sortProperty,
-				String propertyExpression) {
+		public TypePropertyColumn(IModel displayModel, String sortProperty, String propertyExpression) {
 			super(displayModel, sortProperty, propertyExpression);
 		}
 
@@ -287,9 +266,5 @@ public class ScoResultsPage extends BaseResultsPage {
 			String key = new StringBuilder("type.").append(object).toString();
 			return getLocalizer().getString(key, ScoResultsPage.this);
 		}
-		
-		
 	}
-	
-	
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/InteractionProvider.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/InteractionProvider.java
@@ -1,27 +1,67 @@
 package org.sakaiproject.scorm.ui.reporting.util;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 
 import org.sakaiproject.scorm.model.api.Interaction;
+import org.sakaiproject.scorm.model.api.comparator.InteractionComparator;
+import org.sakaiproject.scorm.model.api.comparator.InteractionComparator.CompType;
 import org.sakaiproject.wicket.markup.html.repeater.util.EnhancedDataProvider;
 
 public class InteractionProvider extends EnhancedDataProvider {
 
 	private static final long serialVersionUID = 1L;
-
 	private final List<Interaction> interactions;
-	
+	private final InteractionComparator comp = new InteractionComparator();
+
 	public InteractionProvider(List<Interaction> interactions) {
 		this.interactions = interactions;
+		setSort( "interactionId", true );
 	}
-	
+
 	public Iterator<Interaction> iterator(int first, int count) {
+
+		// Get the sort type
+		SortParam sort = getSort();
+		String sortProp = sort.getProperty();
+		boolean sortAsc = sort.isAscending();
+
+		// Set the sort type in the comparator
+		if( StringUtils.equals( sortProp, "description" ) )
+		{
+			comp.setCompType( CompType.Description );
+		}
+		else if( StringUtils.equals( sortProp, "type" ) )
+		{
+			comp.setCompType( CompType.Type );
+		}
+		else if( StringUtils.equals( sortProp, "result" ) )
+		{
+			comp.setCompType( CompType.Result );
+		}
+		else
+		{
+			comp.setCompType( CompType.InteractionID );
+		}
+
+		// Sort using the comparator in the direction requested
+		if( sortAsc )
+		{
+			Collections.sort( interactions, comp );
+		}
+		else
+		{
+			Collections.sort( interactions, Collections.reverseOrder( comp ) );
+		}
+
+		// Return sub list of sorted collection
 		return interactions.subList(first, first + count).iterator();
 	}
 
 	public int size() {
 		return interactions.size();
 	}
-
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/SummaryProvider.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/SummaryProvider.java
@@ -1,27 +1,67 @@
 package org.sakaiproject.scorm.ui.reporting.util;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
+import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 
 import org.sakaiproject.scorm.model.api.ActivitySummary;
+import org.sakaiproject.scorm.model.api.comparator.ActivitySummaryComparator;
+import org.sakaiproject.scorm.model.api.comparator.ActivitySummaryComparator.CompType;
 import org.sakaiproject.wicket.markup.html.repeater.util.EnhancedDataProvider;
 
 public class SummaryProvider extends EnhancedDataProvider {
 
 	private static final long serialVersionUID = 1L;
-
 	private final List<ActivitySummary> summaries;
-	
+	private final ActivitySummaryComparator comp = new ActivitySummaryComparator();
+
 	public SummaryProvider(List<ActivitySummary> summaries) {
 		this.summaries = summaries;
+		setSort( "title", true );
 	}
 	
 	public Iterator<ActivitySummary> iterator(int first, int count) {
+
+		// Get the sort type
+		SortParam sort = getSort();
+		String sortProp = sort.getProperty();
+		boolean sortAsc = sort.isAscending();
+
+		// Set the sort type in the comparator
+		if( StringUtils.equals( sortProp, "scaled" ) )
+		{
+			comp.setCompType( CompType.Score );
+		}
+		else if( StringUtils.equals( sortProp, "completionStatus" ) )
+		{
+			comp.setCompType( CompType.CompletionStatus );
+		}
+		else if( StringUtils.equals( sortProp, "successStatus" ) )
+		{
+			comp.setCompType( CompType.SuccessStatus );
+		}
+		else
+		{
+			comp.setCompType( CompType.Title );
+		}
+
+		// Sort using the comparator in the direction requested
+		if( sortAsc )
+		{
+			Collections.sort( summaries, comp );
+		}
+		else
+		{
+			Collections.sort( summaries, Collections.reverseOrder( comp ) );
+		}
+
+		// Return sub list of sorted collection
 		return summaries.subList(first, first + count).iterator();
 	}
 
 	public int size() {
 		return summaries.size();
 	}
-
 }

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ImageLinkColumn.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ImageLinkColumn.java
@@ -37,21 +37,21 @@ public class ImageLinkColumn extends AbstractColumn {
 	private ResourceReference iconReference;
 	private String popupWindowName;
 	private String iconProperty = null;
-	
+
 	public ImageLinkColumn(IModel displayModel, Class<?> pageClass, String[] paramPropertyExpressions,
-				ResourceReference iconReference) {
-		this(displayModel, pageClass, paramPropertyExpressions, iconReference, null);
+				ResourceReference iconReference, String sortProperty) {
+		this(displayModel, pageClass, paramPropertyExpressions, iconReference, null, sortProperty);
 	}
-	
+
 	public ImageLinkColumn(IModel displayModel, Class<?> pageClass, String[] paramPropertyExpressions,
-			String iconProperty) {
-		this(displayModel, pageClass, paramPropertyExpressions, null, null);
+			String iconProperty, String sortProperty) {
+		this(displayModel, pageClass, paramPropertyExpressions, null, null, sortProperty);
 		this.iconProperty = iconProperty;
 	}
 
 	public ImageLinkColumn(IModel displayModel, Class<?> pageClass, String[] paramPropertyExpressions, 
-			ResourceReference iconReference, String popupWindowName) {
-		super(displayModel);
+			ResourceReference iconReference, String popupWindowName, String sortProperty) {
+		super(displayModel, sortProperty);
 		this.pageClass = pageClass;
 		this.paramPropertyExpressions = paramPropertyExpressions;
 		this.iconReference = iconReference;
@@ -60,33 +60,32 @@ public class ImageLinkColumn extends AbstractColumn {
 
 	public void populateItem(Item cellItem, String componentId, IModel model) {
 		Object bean = model.getObject();
-		
+
 		final PageParameters params = buildPageParameters(paramPropertyExpressions, bean);
- 		
+
 		if (iconProperty != null) {
 			String iconPropertyValue = String.valueOf(PropertyResolver.getValue(iconProperty, bean));
-		
 			iconReference = getIconPropertyReference(iconPropertyValue);
 		}
-		
+
 		cellItem.add(new IconLink("cell", pageClass, params, iconReference, popupWindowName));
-	}	
+	}
 
 	protected ResourceReference getIconPropertyReference(String iconPropertyValue) {
 		return iconReference;
 	}
-	
+
 	private PageParameters buildPageParameters(String[] propertyExpressions, Object object) {
 		PageParameters params = new PageParameters();
-		
+
 		if (propertyExpressions != null) {
-			for (int i=0;i<propertyExpressions.length;i++) {
-				String paramValue = String.valueOf(PropertyResolver.getValue(propertyExpressions[i], object));	
-				params.add(propertyExpressions[i], paramValue);
+			for( String propertyExpression : propertyExpressions )
+			{
+				String paramValue = String.valueOf( PropertyResolver.getValue( propertyExpression, object ) );
+				params.add( propertyExpression, paramValue );
 			}
 		}
-		
+
 		return params;
 	}
-	
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-126

Currently, the various results tables provide clickable table headers, but the sorting is not implemented.

The attached patch implements sorting for all results tables.
