### PR TITLE
SCO-127 add ability to export SCORM module results to file

### DIFF
--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
@@ -787,9 +787,22 @@ public abstract class ScormResultServiceImpl implements ScormResultService {
 
 		mapInteractions(interactions, dataManager, contentPackageId, learnerId, attemptNumber, false);
 
-		//Map<String, Objective> objectives = report.getObjectives();
-		//mapObjectives(objectives, dataManager, contentPackageId, learnerId, attemptNumber);
+		// Map objectives
+		for( Interaction interaction : interactions )
+		{
+			Map<String, Objective> objectivesMap = new HashMap<>();
+			mapObjectives( objectivesMap, dataManager, contentPackageId, learnerId, attemptNumber );
 
+			List<Objective> objectivesList = interaction.getObjectives();
+			for( String objectiveID : interaction.getObjectiveIds() )
+			{
+				Objective objective = objectivesMap.get( objectiveID );
+				if( objective != null )
+				{
+					objectivesList.add( objective );
+				}
+			}
+		}
 	}
 
 	private void mapValues(ActivitySummary summary, IDataManager dataManager) {

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.java
@@ -63,7 +63,7 @@ public class PackageRemovePage extends ConsoleBasePage {
 	
 	public PackageRemovePage( final PageParameters params )
 	{
-		// bjones86 - SCO-98 - disable buttons and add spinner on submit
+		// SCO-98 - disable buttons and add spinner on submit
 		add( new FileRemoveForm( "removeForm", params ) );
 	}
 	

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.html
@@ -8,7 +8,7 @@
 <body>
 	<wicket:extend>
 	
-		<!-- bjones86 - SCO-94 -->
+		<!-- SCO-94 -->
 		<h3 wicket:id="heading3">[heading goes here]</h3>
 
 		<div wicket:id="interactionPanel"></div>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.properties
@@ -1,6 +1,6 @@
 page.title = Results by Learner, Module, and Interaction
 
-# bjones86 - SCO-94
+# SCO-94
 page.heading.notAllowed=You do not have permission to view these results.
 
 table.title = Objectives

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.html
@@ -8,7 +8,7 @@
 <body>
 	<wicket:extend>
 	
-		<!-- bjones86 - SCO-94 -->
+		<!-- SCO-94 -->
 		<h3 wicket:id="heading1">[heading goes here]</h3>
 
 		<div wicket:id="summaryPresenter"></div>		

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.properties
@@ -1,7 +1,7 @@
 page.title = Results by Learner
 page.instructions = 
 
-# bjones86 - SCO-94
+# SCO-94
 page.heading.notAllowed=You do not have permission to view these results.
 
 table.title = Learning Content Modules

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.html
@@ -8,11 +8,12 @@
 <body>
 	<wicket:extend>
 	
-		<!-- bjones86 - SCO-94 -->
+		<!-- SCO-94 -->
 		<h3 wicket:id="heading">[heading goes here]</h3>
 
+		<input type="button" wicket:id="btnExport" wicket:message="value:export.results.button" />
 		<div wicket:id="attemptPresenter"/>
-		<hr class="itemSeparator"/>		
+		<hr class="itemSeparator"/>
 		<p/>
 		<div wicket:id="details"/>
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -20,10 +20,16 @@
  **********************************************************************************/
 package org.sakaiproject.scorm.ui.reporting.pages;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import org.apache.commons.lang.StringUtils;
 
 import org.apache.commons.logging.Log;
@@ -34,12 +40,20 @@ import org.apache.wicket.extensions.markup.html.repeater.data.table.IColumn;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.DownloadLink;
+import org.apache.wicket.model.AbstractReadOnlyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.util.file.Files;
+import static org.sakaiproject.scorm.api.ScormConstants.*;
+import org.sakaiproject.scorm.model.api.ActivityReport;
+import org.sakaiproject.scorm.model.api.ActivitySummary;
 import org.sakaiproject.scorm.model.api.ContentPackage;
+import org.sakaiproject.scorm.model.api.Interaction;
 import org.sakaiproject.scorm.model.api.LearnerExperience;
+import org.sakaiproject.scorm.model.api.Objective;
 import org.sakaiproject.scorm.model.api.comparator.LearnerExperienceComparator;
 import org.sakaiproject.scorm.model.api.comparator.LearnerExperienceComparator.CompType;
 import org.sakaiproject.scorm.service.api.LearningManagementSystem;
@@ -61,7 +75,7 @@ public class ResultsListPage extends ConsoleBasePage {
 	private static final long serialVersionUID = 1L;
 
 	private static final ResourceReference PAGE_ICON = new ResourceReference(LearnerResultsPage.class, "res/report.png");
-	
+
 	@SuppressWarnings("unused")
 	private static final Log LOG = LogFactory.getLog(ResultsListPage.class);
 
@@ -71,6 +85,15 @@ public class ResultsListPage extends ConsoleBasePage {
 	ScormContentService contentService;
 	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormResultService")
 	ScormResultService resultService;
+
+	private static final String NEW_LINE			= "\n";
+	private static final String DOUBLE_QUOTE		= "\"";
+	private static final String CSV_DELIMITER		= ",";
+	private static final String EMPTY_CELL			= DOUBLE_QUOTE + DOUBLE_QUOTE + CSV_DELIMITER;
+	private static final String SUMMARY_INDENT		= EMPTY_CELL + EMPTY_CELL + EMPTY_CELL + EMPTY_CELL;
+	private static final String INTERACTION_INDENT	= SUMMARY_INDENT + SUMMARY_INDENT;
+	private static final String OBJECTIVE_INDENT	= INTERACTION_INDENT + INTERACTION_INDENT + EMPTY_CELL;
+	private static		 String CSV_HEADERS;
 
 	public ResultsListPage(PageParameters pageParams) {
 		super(pageParams);
@@ -82,24 +105,52 @@ public class ResultsListPage extends ConsoleBasePage {
 		boolean canViewResults = lms.canViewResults( context );
 		Label heading = new Label( "heading", new ResourceModel( "page.heading.notAllowed" ) );
 		add( heading );
+
+		final AttemptDataProvider dataProvider = new AttemptDataProvider(contentPackageId);
+		dataProvider.setFilterConfigurerVisible(true);
+		dataProvider.setTableTitle(getLocalizer().getString("table.title", this));
+
+		// SCO-127
+		buildExportHeaders();
+		AbstractReadOnlyModel<File> fileModel = new AbstractReadOnlyModel<File>()
+		{
+			@Override
+			public File getObject()
+			{
+				File tempFile = null;
+				try
+				{
+					tempFile = File.createTempFile( "export", ".csv" );
+					InputStream data = new ByteArrayInputStream( generateExportCSV( dataProvider ).getBytes() );
+					Files.writeTo( tempFile, data );
+				}
+				catch( IOException ex )
+				{
+					LOG.error( "Could not generate results export: ", ex );
+				}
+
+				return tempFile;
+			}
+		};
+		DownloadLink btnExport = new DownloadLink( "btnExport", fileModel, "export.csv" );
+		btnExport.setDeleteAfterDownload( true );
+		add( btnExport );
+
 		if( !canViewResults )
 		{
+			btnExport.setVisibilityAllowed( false );
 			heading.setVisibilityAllowed( true );
 			add( new WebMarkupContainer( "attemptPresenter" ) );
 			add( new WebMarkupContainer( "details" ) );
 		}
 		else
 		{
-			// bjones86 - SCO-94
+			// SCO-94
 			heading.setVisibilityAllowed( false );
 
 			ContentPackage contentPackage = contentService.getContentPackage(contentPackageId);
 
-			addBreadcrumb(new Model(contentPackage.getTitle()), ResultsListPage.class, new PageParameters(), false);	
-
-			AttemptDataProvider dataProvider = new AttemptDataProvider(contentPackageId);
-			dataProvider.setFilterConfigurerVisible(true);
-			dataProvider.setTableTitle(getLocalizer().getString("table.title", this));
+			addBreadcrumb(new Model(contentPackage.getTitle()), ResultsListPage.class, new PageParameters(), false);
 
 			EnhancedDataPresenter presenter = new EnhancedDataPresenter("attemptPresenter", getColumns(), dataProvider);
 
@@ -107,6 +158,186 @@ public class ResultsListPage extends ConsoleBasePage {
 
 			add(new ContentPackageDetailPanel("details", contentPackage));
 		}
+	}
+
+	/**
+	 * Instantiate the header row for the export, if it hasn't already been instantiated
+	 */
+	private void buildExportHeaders()
+	{
+		if( StringUtils.isBlank( CSV_HEADERS ) )
+		{
+			CSV_HEADERS = DOUBLE_QUOTE + getLocalizer().getString( "export.headers.learner", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.lastAttempt", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.status", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.attempts", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.title", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.score", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.completionStatus", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.successStatus", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.identifier", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.type", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.weighting", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.latency", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.time", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.result", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.description", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.correctResponse", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.learnerResponse", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.objectiveIdentifier", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.objectiveDescription", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.objectiveCompletionStatus", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.objectiveSuccessStatus", this ) + DOUBLE_QUOTE + CSV_DELIMITER + 
+						DOUBLE_QUOTE + getLocalizer().getString( "export.headers.objectiveScore", this ) + DOUBLE_QUOTE + NEW_LINE;
+		}
+	}
+
+	/**
+	 * Export all results for the current module to a CSV file.
+	 * 
+	 * @param dataProvider used to respect current sort order of the UI
+	 * @return string representation of the CSV file
+	 */
+	private String generateExportCSV( AttemptDataProvider attemptProvider )
+	{
+		// Create the column headers
+		StringBuilder csv = new StringBuilder();
+		csv.append( CSV_HEADERS );
+
+		Iterator<LearnerExperience> itr = attemptProvider.iterator( 0, attemptProvider.size() );
+		while( itr.hasNext() )
+		{
+			// Learner info
+			LearnerExperience learner = itr.next();
+			csv.append( DOUBLE_QUOTE ).append( learner.getLearnerName() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+			csv.append( DOUBLE_QUOTE ).append( Objects.toString( learner.getLastAttemptDate(), "" ) ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+			csv.append( DOUBLE_QUOTE ).append( getStatusLabel( learner.getStatus() ) ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+			csv.append( DOUBLE_QUOTE ).append( learner.getNumberOfAttempts() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+
+			// Get the summaries for all attempts for the current user
+			List<ActivitySummary> summaries = new ArrayList<>();
+			for( int i = 1; i <= learner.getNumberOfAttempts(); i++ )
+			{
+				summaries.addAll( resultService.getActivitySummaries( learner.getContentPackageId(), learner.getLearnerId(), i ) );
+			}
+
+			if( summaries.isEmpty() )
+			{
+				csv.append( NEW_LINE );
+			}
+
+			for( int i = 0; i < summaries.size(); i++ )
+			{
+				if( i != 0 )
+				{
+					csv.append( SUMMARY_INDENT );
+				}
+
+				// Summary info
+				ActivitySummary summary = summaries.get( i );
+				csv.append( DOUBLE_QUOTE ).append( summary.getTitle() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+				csv.append( DOUBLE_QUOTE ).append( summary.getScaled() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+				csv.append( DOUBLE_QUOTE ).append( Objects.toString( summary.getCompletionStatus(), "" ) ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+				csv.append( DOUBLE_QUOTE ).append( Objects.toString( summary.getSuccessStatus(), "" ) ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+
+				// Get the interactions
+				ActivityReport report = resultService.getActivityReport( summary.getContentPackageId(), summary.getLearnerId(), summary.getAttemptNumber(), summary.getScoId() );
+				if( report != null )
+				{
+					List<Interaction> interactions = report.getInteractions();
+					if( interactions.isEmpty() )
+					{
+						csv.append( NEW_LINE );
+					}
+
+					for( int j = 0; j < interactions.size(); j++ )
+					{
+						if( j != 0 )
+						{
+							csv.append( INTERACTION_INDENT );
+						}
+
+						// Interaction info
+						Interaction interaction = interactions.get( j );
+						StringBuilder correctResponses = new StringBuilder();
+						for( String correctResponse : interaction.getCorrectResponses() )
+						{
+							if( StringUtils.isNotEmpty( correctResponse ) )
+							{
+								correctResponses.append( correctResponse );
+							}
+						}
+						csv.append( DOUBLE_QUOTE ).append( interaction.getInteractionId() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( interaction.getType() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( interaction.getWeighting() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( interaction.getLatency() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( interaction.getTimestamp() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( interaction.getResult() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( interaction.getDescription() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( correctResponses.toString() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+						csv.append( DOUBLE_QUOTE ).append( interaction.getLearnerResponse() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+
+						// Objective info
+						List<Objective> objectives = interaction.getObjectives();
+						for( int k = 0; k < objectives.size(); k++ )
+						{
+							if( k != 0 )
+							{
+								csv.append( OBJECTIVE_INDENT );
+							}
+
+							Objective objective = objectives.get( k );
+							csv.append( DOUBLE_QUOTE ).append( objective.getId() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+							csv.append( DOUBLE_QUOTE ).append( Objects.toString( objective.getDescription(), "" ) ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+							csv.append( DOUBLE_QUOTE ).append( Objects.toString( objective.getCompletionStatus(), "" ) ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+							csv.append( DOUBLE_QUOTE ).append( Objects.toString( objective.getSuccessStatus(), "" ) ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
+							csv.append( DOUBLE_QUOTE ).append( Objects.toString( objective.getScore().getScaled(), "" ) ).append( DOUBLE_QUOTE ).append( NEW_LINE );
+						}
+
+						if( objectives.isEmpty() )
+						{
+							csv.append( NEW_LINE );
+						}
+					}
+				}
+				else
+				{
+					csv.append( NEW_LINE );
+				}
+			}
+		}
+
+		return csv.toString();
+	}
+
+	/**
+	 * Determine the proper status label for the give status integer
+	 * @param status status integer
+	 * @return the String status label corresponding to the status integer given
+	 */
+	private String getStatusLabel( int status )
+	{
+		switch( status )
+		{
+			case NOT_ACCESSED:
+			{
+				return getLocalizer().getString( "access.status.not.accessed", this );
+			}
+			case INCOMPLETE:
+			{
+				return getLocalizer().getString( "access.status.incomplete", this );
+			}
+			case COMPLETED:
+			{
+				return getLocalizer().getString( "access.status.completed", this );
+			}
+			case GRADED:
+			{
+				return getLocalizer().getString( "access.status.graded", this );
+			}
+		}
+
+		return "";
 	}
 
 	private List<IColumn> getColumns() {

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.properties
@@ -2,7 +2,7 @@ page.title = Results
 sakai.scorm.singlepackage.tool.title=Results
 page.instructions = Select a learner name from the list below to view results for that individual
 
-# bjones86 - SCO-94
+# SCO-94
 page.heading.notAllowed=You do not have permission to view these results.
 
 table.title = Learners
@@ -34,6 +34,27 @@ access.status.incomplete = Incomplete
 access.status.completed = Accessed
 access.status.graded = Graded
 
-
-
-
+# SCO-127
+export.results.button=Export Results to CSV
+export.headers.learner=Learner
+export.headers.lastAttempt=Last Attempt Date
+export.headers.status=Status
+export.headers.attempts=Attempts
+export.headers.title=Title
+export.headers.score=Score
+export.headers.completionStatus=Completion Status
+export.headers.successStatus=Success Status
+export.headers.identifier=Identifier
+export.headers.type=Type
+export.headers.weighting=Weighting
+export.headers.latency=Latency
+export.headers.time=Time
+export.headers.result=Result
+export.headers.description=Description
+export.headers.correctResponse=Correct Response
+export.headers.learnerResponse=Learner Response
+export.headers.objectiveIdentifier=Objective Identifier
+export.headers.objectiveDescription=Objective Description
+export.headers.objectiveCompletionStatus=Objection Completion Status
+export.headers.objectiveSuccessStatus=Objective Success Status
+export.headers.objectiveScore=Objective Score

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.html
@@ -8,7 +8,7 @@
 <body>
 	<wicket:extend>
 	
-		<!-- bjones86 - SCO-94 -->
+		<!-- SCO-94 -->
 		<h3 wicket:id="heading2">[heading goes here]</h3>
 
 		<h4><wicket:message key="runtime.data.title"></wicket:message></h4>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.properties
@@ -1,6 +1,6 @@
 page.title = Results by Learner and Module
 
-# bjones86 - SCO-94
+# SCO-94
 page.heading.notAllowed=You do not have permission to view these results.
 
 runtime.data.title = Learning Module Details

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
@@ -43,7 +43,7 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 	private static final ResourceReference PAGE_ICON = new ResourceReference(ConsoleBasePage.class, "res/table_add.png");
 	private static final Log LOG = LogFactory.getLog(FileUploadForm.class);
 
-	// bjones86 - SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
+	// SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
 	private static final String SAK_PROP_SCORM_ENABLE_EMAIL = "scorm.enable.email";
 	@SpringBean( name = "org.sakaiproject.component.api.ServerConfigurationService" )
 	ServerConfigurationService serverConfigurationService;
@@ -110,7 +110,7 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 			add( fileUploadField );
 			add(new CheckBox("fileValidated"));
 
-			// bjones86 - SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
+			// SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
 			@SuppressWarnings( { "unchecked", "rawtypes" } )
 			DropDownChoice emailNotificationDropDown = new DropDownChoice( "priority", 
 					Arrays.asList( new Integer[] { NotificationService.NOTI_NONE, NotificationService.NOTI_OPTIONAL, 
@@ -151,7 +151,7 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 					}
 			);
 
-			// bjones86 - SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
+			// SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
 			boolean enableEmail = serverConfigurationService.getBoolean( SAK_PROP_SCORM_ENABLE_EMAIL, true );
 			Label priorityLabel = new Label( "lblPriority", new ResourceModel( "upload.priority.label" ) );
 			if( !enableEmail )
@@ -164,7 +164,7 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 			add( priorityLabel );
 			add( emailNotificationDropDown );
 
-			// bjones86 - SCO-98 - disable buttons on submit, add spinner
+			// SCO-98 - disable buttons on submit, add spinner
 			final CancelButton btnCancel = new CancelButton( "btnCancel", PackageListPage.class );
 			IndicatingAjaxButton btnSubmit = new IndicatingAjaxButton( "btnSubmit", this )
 			{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-127

Several faculty members at our institution have requested the ability to export the results of a SCORM module, as it can be arduous for them to drill down through the interfaces for large numbers of users.

The attached patch introduces a new button on the top level ResultsListPage which will export all results for all learners to a CSV file.
