### PR TITLE
SCO-133 fix compile (java6) errors in 10.x

### DIFF
--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
@@ -790,7 +790,7 @@ public abstract class ScormResultServiceImpl implements ScormResultService {
 		// Map objectives
 		for( Interaction interaction : interactions )
 		{
-			Map<String, Objective> objectivesMap = new HashMap<>();
+			Map<String, Objective> objectivesMap = new HashMap<String, Objective>();
 			mapObjectives( objectivesMap, dataManager, contentPackageId, learnerId, attemptNumber );
 
 			List<Objective> objectivesList = interaction.getObjectives();

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -215,7 +215,7 @@ public class ResultsListPage extends ConsoleBasePage {
 			csv.append( DOUBLE_QUOTE ).append( learner.getNumberOfAttempts() ).append( DOUBLE_QUOTE ).append( CSV_DELIMITER );
 
 			// Get the summaries for all attempts for the current user
-			List<ActivitySummary> summaries = new ArrayList<>();
+			List<ActivitySummary> summaries = new ArrayList<ActivitySummary>();
 			for( int i = 1; i <= learner.getNumberOfAttempts(); i++ )
 			{
 				summaries.addAll( resultService.getActivitySummaries( learner.getContentPackageId(), learner.getLearnerId(), i ) );


### PR DESCRIPTION
Merged a commit that used diamond operators, forgot that 10.x has -source 1.6, thus compile time errors. Fix and PR/push to 10.x branch.
