### PR TITLE
SCO-128 SCORM Player errors don't bubble to portal

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/SingleScormPackageApplication.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/SingleScormPackageApplication.java
@@ -6,8 +6,13 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.wicket.Page;
+import org.apache.wicket.Request;
 import org.apache.wicket.RequestCycle;
+import org.apache.wicket.Response;
+import org.apache.wicket.protocol.http.WebRequest;
+import org.apache.wicket.protocol.http.WebRequestCycle;
 import org.apache.wicket.protocol.http.WebRequestCycleProcessor;
+import org.apache.wicket.protocol.http.WebResponse;
 import org.apache.wicket.request.IRequestCycleProcessor;
 import org.apache.wicket.settings.IExceptionSettings;
 import org.sakaiproject.component.cover.ComponentManager;
@@ -21,30 +26,43 @@ import org.sakaiproject.wicket.protocol.http.SakaiWebApplication;
 
 public class SingleScormPackageApplication extends SakaiWebApplication {
 
-	private static Log log = LogFactory.getLog(SingleScormPackageApplication.class);
+	private static final Log LOG = LogFactory.getLog(SingleScormPackageApplication.class);
 
 	@Override
 	public void init() {
-		log.info(">>> Initializing singleScormPackageApplication");
+		LOG.info(">>> Initializing singleScormPackageApplication");
 		super.init();
-		
+
 		mount(new ContentPackageResourceMountStrategy("contentpackages"));
 
 		getExceptionSettings().setUnexpectedExceptionDisplay(IExceptionSettings.SHOW_INTERNAL_ERROR_PAGE);
-		
+
 		getResourceSettings().setDisableGZipCompression(false);
 	}
-	
+
+	@Override
+	public RequestCycle newRequestCycle( Request request, Response response )
+	{
+		return new WebRequestCycle( this, (WebRequest) request, (WebResponse) response )
+		{
+			@Override
+			public Page onRuntimeException( Page page, RuntimeException e )
+			{
+				// Let Sakai ErrorReportHandler (BugReport) handle errors
+				throw e;
+			}
+		};
+	}
+
 	@Override
 	protected IRequestCycleProcessor newRequestCycleProcessor() {
-	    return new WebRequestCycleProcessor(){
-	    	@Override
-	    	public void respond(RuntimeException e, RequestCycle requestCycle) {
-	    		log.debug("Exception occured during normal web processing (may be a 'valid' exception)", e);
-	    	    super.respond(e, requestCycle);
-	    	}
-	    	
-	    };
+		return new WebRequestCycleProcessor(){
+			@Override
+			public void respond(RuntimeException e, RequestCycle requestCycle) {
+				LOG.debug("Exception occured during normal web processing (may be a 'valid' exception)", e);
+				super.respond(e, requestCycle);
+			}
+		};
 	}
 
 	@Override
@@ -61,5 +79,4 @@ public class SingleScormPackageApplication extends SakaiWebApplication {
 		}
 		return NotConfiguredPage.class;
 	}
-
 } // class


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-128

Errors in the SCORM Player produce the default Wicket "Internal Error" page (orange text, etc). All other tools in Sakai, including other Wicket tools, are made to ignore handling errors and let them bubble up to portal, so they are later caught by the Bug Report (ErrorReportHandler) system.

The attached patch alters the request cycle of SCORM Player and the SCORM Player for Single Package such that they respect this contract, and let the ErrorReportHandler handle any uncaught exceptions. This provides a more consistent look and feel with the rest of Sakai.
