### PR TITLE
SCO-134 update license headers

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,176 @@
+Educational Community License, Version 2.0, April 2007
+
+The Educational Community License version 2.0 ("ECL") consists of the Apache 2.0
+license, modified to change the scope of the patent grant in section 3 to be
+specific to the needs of the education communities using this license. The
+original Apache 2.0 license can be found at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed. Any
+patent license granted hereby with respect to contributions by an individual
+employed by an institution or organization is limited to patent claims where the
+individual that is the author of the Work is also the inventor of the patent
+claims licensed, and where the organization or institution has the right to
+grant such license under applicable grant and research funding agreements. No
+other express or implied licenses are granted.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+   1. You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+   2. You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+   3. You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain to
+any part of the Derivative Works; and
+   4. If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy of
+the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part of
+the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally appear.
+The contents of the NOTICE file are for informational purposes only and do
+not modify the License. You may add Your own attribution notices within
+Derivative Works that You distribute, alongside or as an addendum to the
+NOTICE text from the Work, provided that such additional attribution notices
+cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.

--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 README
 
-This project was originally developed and maintained by UC Davis and made available on an ECL 1 license. 
+This project was originally developed and maintained by UC Davis and made available on an ECL 1 license.
+Since the project was moved to GitHub, the license has been updated to ECL 2.
 
 UC Davis never got around to finishing the project and never took deployed the tool to production.
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,24 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>1.8</version>
+                <configuration>
+                    <licenseName>ecl_v2</licenseName>
+                    <licenseResolver>classpath://org/sakaiproject</licenseResolver>
+                    <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.sakaiproject.license</groupId>
+                        <artifactId>ecl-license</artifactId>
+                        <version>1.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/scorm-api/pom.xml
+++ b/scorm-api/pom.xml
@@ -65,5 +65,19 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/scorm-api/src/java/org/adl/api/ecmascript/APIErrorCodes.java
+++ b/scorm-api/src/java/org/adl/api/ecmascript/APIErrorCodes.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/api/ecmascript/IErrorManager.java
+++ b/scorm-api/src/java/org/adl/api/ecmascript/IErrorManager.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.adl.api.ecmascript;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/api/ecmascript/SCORM12APIInterface.java
+++ b/scorm-api/src/java/org/adl/api/ecmascript/SCORM12APIInterface.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/api/ecmascript/SCORM13APIInterface.java
+++ b/scorm-api/src/java/org/adl/api/ecmascript/SCORM13APIInterface.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/datamodels/Children.java
+++ b/scorm-api/src/java/org/adl/datamodels/Children.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/Count.java
+++ b/scorm-api/src/java/org/adl/datamodels/Count.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMDelimiter.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/DMDelimiter.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/DMDelimiter.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMDelimiter.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMDelimiterDescriptor.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/DMDelimiterDescriptor.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/DMDelimiterDescriptor.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMDelimiterDescriptor.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMElement.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/DMElement.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/DMElement.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMElement.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMElementDescriptor.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/DMElementDescriptor.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/DMElementDescriptor.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMElementDescriptor.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMErrorCodes.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMErrorCodes.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMFactory.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMFactory.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/datamodels/DMInterface.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMInterface.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMProcessingInfo.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/DMProcessingInfo.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/DMProcessingInfo.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMProcessingInfo.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMRequest.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMRequest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMTimeUtility.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMTimeUtility.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DMTypeValidator.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/DMTypeValidator.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/DMTypeValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/DMTypeValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/DataModel.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/DataModel.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/DataModel.java
+++ b/scorm-api/src/java/org/adl/datamodels/DataModel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/IDataManager.java
+++ b/scorm-api/src/java/org/adl/datamodels/IDataManager.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.adl.datamodels;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/datamodels/IDataModel.java
+++ b/scorm-api/src/java/org/adl/datamodels/IDataModel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.adl.datamodels;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/datamodels/RequestDelimiter.java
+++ b/scorm-api/src/java/org/adl/datamodels/RequestDelimiter.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/RequestToken.java
+++ b/scorm-api/src/java/org/adl/datamodels/RequestToken.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/SCODataManager.hbm.xml
+++ b/scorm-api/src/java/org/adl/datamodels/SCODataManager.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="org.adl.datamodels">

--- a/scorm-api/src/java/org/adl/datamodels/SCODataManager.java
+++ b/scorm-api/src/java/org/adl/datamodels/SCODataManager.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/DateTimeValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/DateTimeValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/DurationValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/DurationValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/IntRangeValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/IntRangeValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/InteractionTrunc.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/InteractionTrunc.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/InteractionValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/InteractionValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/LangStringValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/LangStringValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/RealRangeValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/RealRangeValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/ResultValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/ResultValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/SPMRangeValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/SPMRangeValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/URIValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/URIValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/datatypes/VocabularyValidator.java
+++ b/scorm-api/src/java/org/adl/datamodels/datatypes/VocabularyValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/ieee/IValidatorFactory.java
+++ b/scorm-api/src/java/org/adl/datamodels/ieee/IValidatorFactory.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.adl.datamodels.ieee;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/datamodels/ieee/SCORM_2004_DM.java
+++ b/scorm-api/src/java/org/adl/datamodels/ieee/SCORM_2004_DM.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/datamodels/ieee/SCORM_2004_DMElement.java
+++ b/scorm-api/src/java/org/adl/datamodels/ieee/SCORM_2004_DMElement.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/ieee/Version.java
+++ b/scorm-api/src/java/org/adl/datamodels/ieee/Version.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/nav/SCORM_2004_NAV_DM.java
+++ b/scorm-api/src/java/org/adl/datamodels/nav/SCORM_2004_NAV_DM.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/nav/SCORM_2004_NAV_DMElement.java
+++ b/scorm-api/src/java/org/adl/datamodels/nav/SCORM_2004_NAV_DMElement.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/datamodels/ssp/AbstractSSPDataModel.java
+++ b/scorm-api/src/java/org/adl/datamodels/ssp/AbstractSSPDataModel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.datamodels.ssp;
 
 import java.net.URL;

--- a/scorm-api/src/java/org/adl/datamodels/ssp/SSP_DMErrorCodes.java
+++ b/scorm-api/src/java/org/adl/datamodels/ssp/SSP_DMErrorCodes.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/datamodels/ssp/SSP_DataModel.java
+++ b/scorm-api/src/java/org/adl/datamodels/ssp/SSP_DataModel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/logging/ADLMessageCollection.java
+++ b/scorm-api/src/java/org/adl/logging/ADLMessageCollection.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/logging/DetailedLogMessageCollection.java
+++ b/scorm-api/src/java/org/adl/logging/DetailedLogMessageCollection.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/sequencer/ADLAuxiliaryResource.java
+++ b/scorm-api/src/java/org/adl/sequencer/ADLAuxiliaryResource.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/ADLDuration.java
+++ b/scorm-api/src/java/org/adl/sequencer/ADLDuration.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/ADLObjStatus.java
+++ b/scorm-api/src/java/org/adl/sequencer/ADLObjStatus.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/ADLSeqUtilities.java
+++ b/scorm-api/src/java/org/adl/sequencer/ADLSeqUtilities.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/ADLTOC.java
+++ b/scorm-api/src/java/org/adl/sequencer/ADLTOC.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/ADLTracking.java
+++ b/scorm-api/src/java/org/adl/sequencer/ADLTracking.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/ADLValidRequests.hbm.xml
+++ b/scorm-api/src/java/org/adl/sequencer/ADLValidRequests.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-access="field" package="org.adl.sequencer">

--- a/scorm-api/src/java/org/adl/sequencer/ADLValidRequests.java
+++ b/scorm-api/src/java/org/adl/sequencer/ADLValidRequests.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/ActivityNode.java
+++ b/scorm-api/src/java/org/adl/sequencer/ActivityNode.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 import java.util.Collections;

--- a/scorm-api/src/java/org/adl/sequencer/IActivityTree.java
+++ b/scorm-api/src/java/org/adl/sequencer/IActivityTree.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 import java.util.List;

--- a/scorm-api/src/java/org/adl/sequencer/IDuration.java
+++ b/scorm-api/src/java/org/adl/sequencer/IDuration.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 public interface IDuration {

--- a/scorm-api/src/java/org/adl/sequencer/ILaunch.java
+++ b/scorm-api/src/java/org/adl/sequencer/ILaunch.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 public interface ILaunch {

--- a/scorm-api/src/java/org/adl/sequencer/ISeqActivity.java
+++ b/scorm-api/src/java/org/adl/sequencer/ISeqActivity.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/sequencer/ISeqActivityTree.java
+++ b/scorm-api/src/java/org/adl/sequencer/ISeqActivityTree.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 import java.util.List;

--- a/scorm-api/src/java/org/adl/sequencer/ISeqRollupRuleset.java
+++ b/scorm-api/src/java/org/adl/sequencer/ISeqRollupRuleset.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 public interface ISeqRollupRuleset {

--- a/scorm-api/src/java/org/adl/sequencer/ISeqRule.java
+++ b/scorm-api/src/java/org/adl/sequencer/ISeqRule.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 public interface ISeqRule {

--- a/scorm-api/src/java/org/adl/sequencer/ISeqRuleset.java
+++ b/scorm-api/src/java/org/adl/sequencer/ISeqRuleset.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 public interface ISeqRuleset {

--- a/scorm-api/src/java/org/adl/sequencer/ISequencer.java
+++ b/scorm-api/src/java/org/adl/sequencer/ISequencer.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/sequencer/IValidRequests.java
+++ b/scorm-api/src/java/org/adl/sequencer/IValidRequests.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 import java.util.Map;

--- a/scorm-api/src/java/org/adl/sequencer/SeqActivity.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqActivity.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqActivityComparator.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqActivityComparator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.sequencer;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/sequencer/SeqActivityStateAccess.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqActivityStateAccess.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqActivityTrackingAccess.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqActivityTrackingAccess.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqActivityTree.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqActivityTree.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqCondition.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqCondition.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqConditionSet.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqConditionSet.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqNavRequests.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqNavRequests.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqObjective.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqObjective.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqObjectiveMap.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqObjectiveMap.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqObjectiveTracking.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqObjectiveTracking.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqRollupRule.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqRollupRule.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqRollupRuleset.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqRollupRuleset.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqRule.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqRule.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SeqRuleset.java
+++ b/scorm-api/src/java/org/adl/sequencer/SeqRuleset.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/sequencer/SequencerMappings.hbm.xml
+++ b/scorm-api/src/java/org/adl/sequencer/SequencerMappings.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" default-access="field" package="org.adl.sequencer" default-lazy="false">

--- a/scorm-api/src/java/org/adl/util/EnvironmentVariable.java
+++ b/scorm-api/src/java/org/adl/util/EnvironmentVariable.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/util/LogMessage.java
+++ b/scorm-api/src/java/org/adl/util/LogMessage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/util/MessageBox.java
+++ b/scorm-api/src/java/org/adl/util/MessageBox.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/util/MessageCollection.java
+++ b/scorm-api/src/java/org/adl/util/MessageCollection.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/util/MessageType.java
+++ b/scorm-api/src/java/org/adl/util/MessageType.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/util/Messages.java
+++ b/scorm-api/src/java/org/adl/util/Messages.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-api/src/java/org/adl/util/debug/ADLSimpleFormatter.java
+++ b/scorm-api/src/java/org/adl/util/debug/ADLSimpleFormatter.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/util/debug/DebugIndicator.java
+++ b/scorm-api/src/java/org/adl/util/debug/DebugIndicator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/util/debug/LogConfig.java
+++ b/scorm-api/src/java/org/adl/util/debug/LogConfig.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/util/messages.properties
+++ b/scorm-api/src/java/org/adl/util/messages.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM API
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 ################################################################################
 ## 
 ## Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/adl/validator/IValidator.java
+++ b/scorm-api/src/java/org/adl/validator/IValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.validator;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/validator/IValidatorOutcome.java
+++ b/scorm-api/src/java/org/adl/validator/IValidatorOutcome.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.adl.validator;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/validator/contentpackage/ILaunchData.java
+++ b/scorm-api/src/java/org/adl/validator/contentpackage/ILaunchData.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.adl.validator.contentpackage;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/validator/contentpackage/IManifestMap.java
+++ b/scorm-api/src/java/org/adl/validator/contentpackage/IManifestMap.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.adl.validator.contentpackage;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/adl/validator/contentpackage/IMetadataData.java
+++ b/scorm-api/src/java/org/adl/validator/contentpackage/IMetadataData.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.validator.contentpackage;
 
 import org.w3c.dom.Node;

--- a/scorm-api/src/java/org/adl/validator/contentpackage/LaunchData.hbm.xml
+++ b/scorm-api/src/java/org/adl/validator/contentpackage/LaunchData.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" package="org.adl.validator.contentpackage" default-lazy="false">

--- a/scorm-api/src/java/org/adl/validator/contentpackage/LaunchData.java
+++ b/scorm-api/src/java/org/adl/validator/contentpackage/LaunchData.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-api/src/java/org/sakaiproject/scorm/adl/ADLConsultant.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/adl/ADLConsultant.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.adl;
 
 import org.adl.datamodels.IDataManager;

--- a/scorm-api/src/java/org/sakaiproject/scorm/api/ScormConstants.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/api/ScormConstants.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.api;
 
 public interface ScormConstants {

--- a/scorm-api/src/java/org/sakaiproject/scorm/content/api/Addable.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/content/api/Addable.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.api;
 
 import java.io.File;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/LearnerDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/LearnerDao.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao;
 
 import java.util.List;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/api/ActivityTreeHolderDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/api/ActivityTreeHolderDao.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.api;
 
 import org.sakaiproject.scorm.model.api.ActivityTreeHolder;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/api/AttemptDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/api/AttemptDao.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.api;
 
 import java.util.List;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/api/ContentPackageDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/api/ContentPackageDao.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.api;
 
 import java.util.List;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/api/ContentPackageManifestDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/api/ContentPackageManifestDao.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/api/DataManagerDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/api/DataManagerDao.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.api;
 
 import java.util.List;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/api/SeqActivityDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/api/SeqActivityDao.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.api;
 
 import org.sakaiproject.scorm.model.api.SeqActivitySnapshot;

--- a/scorm-api/src/java/org/sakaiproject/scorm/dao/api/SeqActivityTreeDao.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/dao/api/SeqActivityTreeDao.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.api;
 
 import org.adl.sequencer.ISeqActivityTree;

--- a/scorm-api/src/java/org/sakaiproject/scorm/entity/ScormEntity.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/entity/ScormEntity.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.entity;
 
 import org.apache.commons.lang.ObjectUtils;

--- a/scorm-api/src/java/org/sakaiproject/scorm/entity/ScormEntityProvider.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/entity/ScormEntityProvider.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.entity;
 
 import org.sakaiproject.entitybroker.entityprovider.EntityProvider;

--- a/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ContentPackageExistsException.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ContentPackageExistsException.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.exceptions;
 
 public class ContentPackageExistsException extends Exception {

--- a/scorm-api/src/java/org/sakaiproject/scorm/exceptions/InvalidArchiveException.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/exceptions/InvalidArchiveException.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.exceptions;
 
 public class InvalidArchiveException extends Exception {

--- a/scorm-api/src/java/org/sakaiproject/scorm/exceptions/LearnerNotDefinedException.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/exceptions/LearnerNotDefinedException.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.exceptions;
 
 public class LearnerNotDefinedException extends Exception {

--- a/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ResourceNotDeletedException.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ResourceNotDeletedException.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.exceptions;
 
 public class ResourceNotDeletedException extends Exception {

--- a/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ResourceNotFoundException.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ResourceNotFoundException.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.exceptions;
 
 public class ResourceNotFoundException extends Exception {

--- a/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ResourceStorageException.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ResourceStorageException.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.exceptions;
 
 /**

--- a/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ValidationException.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/exceptions/ValidationException.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.exceptions;
 
 public class ValidationException extends Exception {

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivityReport.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivityReport.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivitySummary.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivitySummary.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivityTreeHolder.hbm.xml
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivityTreeHolder.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" package="org.sakaiproject.scorm.model.api" default-lazy="false">

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivityTreeHolder.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ActivityTreeHolder.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Archive.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Archive.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Attempt.hbm.xml
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Attempt.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" package="org.sakaiproject.scorm.model.api" default-lazy="false">

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Attempt.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Attempt.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIData.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIData.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIField.hbm.xml
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIField.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" package="org.sakaiproject.scorm.model.api" default-lazy="false">

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIField.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIField.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.util.LinkedList;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIFieldGroup.hbm.xml
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIFieldGroup.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" package="org.sakaiproject.scorm.model.api" default-lazy="false">

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIFieldGroup.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIFieldGroup.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.util.LinkedList;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackage.hbm.xml
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackage.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" package="org.sakaiproject.scorm.model.api" default-lazy="false">

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackage.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageManifest.hbm.xml
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageManifest.hbm.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM API
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD//EN"
 	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping default-cascade="all" package="org.sakaiproject.scorm.model.api" default-lazy="false">

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageManifest.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageManifest.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageResource.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageResource.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.InputStream;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Interaction.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Interaction.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/LearnerExperience.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Objective.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Objective.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/PackageConfiguration.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/PackageConfiguration.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 public class PackageConfiguration {

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Progress.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Progress.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ScoBean.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ScoBean.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ScoBeanImpl.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ScoBeanImpl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import org.adl.api.ecmascript.IErrorManager;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Score.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Score.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/SeqActivitySnapshot.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/SeqActivitySnapshot.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 public class SeqActivitySnapshot {

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/SeqActivityTreeSnapshot.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/SeqActivityTreeSnapshot.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import org.adl.sequencer.SeqActivity;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/SessionBean.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/SessionBean.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/ActivitySummaryComparator.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/ActivitySummaryComparator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api.comparator;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/InteractionComparator.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/InteractionComparator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api.comparator;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/comparator/LearnerExperienceComparator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.model.api.comparator;
 
 import java.io.Serializable;

--- a/scorm-api/src/java/org/sakaiproject/scorm/navigation/INavigable.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/navigation/INavigable.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.navigation;
 
 import org.sakaiproject.scorm.model.api.SessionBean;

--- a/scorm-api/src/java/org/sakaiproject/scorm/navigation/INavigationEvent.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/navigation/INavigationEvent.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.navigation;
 
 public interface INavigationEvent {

--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/LearningManagementSystem.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/LearningManagementSystem.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.api;
 
 import org.sakaiproject.scorm.exceptions.LearnerNotDefinedException;

--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormApplicationService.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormApplicationService.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.api;
 
 import org.sakaiproject.scorm.model.api.ScoBean;

--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormContentService.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormContentService.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.api;
 
 import java.util.List;

--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormEntityProvider.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormEntityProvider.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.api;
 
 public interface ScormEntityProvider {

--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormResourceService.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormResourceService.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.api;
 
 import java.io.InputStream;

--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormResultService.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormResultService.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.api;
 
 import java.util.List;

--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormSequencingService.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormSequencingService.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.api;
 
 import javax.swing.tree.TreeModel;

--- a/scorm-api/src/test/org/adl/datamodels/DMTimeUtilityTest.java
+++ b/scorm-api/src/test/org/adl/datamodels/DMTimeUtilityTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM API
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.datamodels;
 
 import junit.framework.TestCase;

--- a/scorm-impl/adl/pom.xml
+++ b/scorm-impl/adl/pom.xml
@@ -84,4 +84,21 @@
             <type>jar</type>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/scorm-impl/adl/src/java/org/adl/api/ecmascript/APIErrorManager.java
+++ b/scorm-impl/adl/src/java/org/adl/api/ecmascript/APIErrorManager.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/datamodels/datatypes/DateTimeValidatorImpl.java
+++ b/scorm-impl/adl/src/java/org/adl/datamodels/datatypes/DateTimeValidatorImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/datamodels/datatypes/InteractionValidatorImpl.java
+++ b/scorm-impl/adl/src/java/org/adl/datamodels/datatypes/InteractionValidatorImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/datamodels/ieee/ValidatorFactory.java
+++ b/scorm-impl/adl/src/java/org/adl/datamodels/ieee/ValidatorFactory.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.datamodels.ieee;
 
 import org.adl.datamodels.datatypes.DateTimeValidator;

--- a/scorm-impl/adl/src/java/org/adl/parsers/dom/ADLDOMParser.java
+++ b/scorm-impl/adl/src/java/org/adl/parsers/dom/ADLDOMParser.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/parsers/dom/DOMTreeUtility.java
+++ b/scorm-impl/adl/src/java/org/adl/parsers/dom/DOMTreeUtility.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLDuration.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLDuration.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLLaunch.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLLaunch.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLSeqParser.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLSeqParser.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLSequencer.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/ADLSequencer.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqActivityStateAccess.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqActivityStateAccess.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqActivityTrackingAccess.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqActivityTrackingAccess.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqNavigation.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqNavigation.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqReportActivityStatus.java
+++ b/scorm-impl/adl/src/java/org/adl/sequencer/impl/SeqReportActivityStatus.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/EnvironmentVariable.java
+++ b/scorm-impl/adl/src/java/org/adl/util/EnvironmentVariable.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/util/LogMessage.java
+++ b/scorm-impl/adl/src/java/org/adl/util/LogMessage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/MessageBox.java
+++ b/scorm-impl/adl/src/java/org/adl/util/MessageBox.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/MessageCollection.java
+++ b/scorm-impl/adl/src/java/org/adl/util/MessageCollection.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/MessageType.java
+++ b/scorm-impl/adl/src/java/org/adl/util/MessageType.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/Messages.java
+++ b/scorm-impl/adl/src/java/org/adl/util/Messages.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/util/debug/ADLSimpleFormatter.java
+++ b/scorm-impl/adl/src/java/org/adl/util/debug/ADLSimpleFormatter.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/debug/DebugIndicator.java
+++ b/scorm-impl/adl/src/java/org/adl/util/debug/DebugIndicator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/debug/LogConfig.java
+++ b/scorm-impl/adl/src/java/org/adl/util/debug/LogConfig.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/messages.properties
+++ b/scorm-impl/adl/src/java/org/adl/util/messages.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM ADL Impl
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 ################################################################################
 ## 
 ## Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/util/servlet/ServletWriter.java
+++ b/scorm-impl/adl/src/java/org/adl/util/servlet/ServletWriter.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/util/support/SupportVerifier.java
+++ b/scorm-impl/adl/src/java/org/adl/util/support/SupportVerifier.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/util/zip/UnZipHandler.java
+++ b/scorm-impl/adl/src/java/org/adl/util/zip/UnZipHandler.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/validator/ADLSCORMValidator.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/ADLSCORMValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/ADLValidatorOutcome.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/ADLValidatorOutcome.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/DOMRulesCreator.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/DOMRulesCreator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/validator/RulesValidator.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/RulesValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/CPValidator.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/CPValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
  **
  ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/CaseSensitiveCollection.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/CaseSensitiveCollection.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/ManifestHandler.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/ManifestHandler.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/ManifestMap.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/ManifestMap.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/MetadataData.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/MetadataData.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/ParameterChecker.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/ParameterChecker.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/XSDHandler.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/XSDHandler.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/rules/cp_contentaggregationRules.xml
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/rules/cp_contentaggregationRules.xml
@@ -1,4 +1,23 @@
 <!--
+  #%L
+  SCORM ADL Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<!--
 ******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/contentpackage/rules/cp_resourceRules.xml
+++ b/scorm-impl/adl/src/java/org/adl/validator/contentpackage/rules/cp_resourceRules.xml
@@ -1,4 +1,23 @@
 <!--
+  #%L
+  SCORM ADL Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<!--
 ******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/metadata/MDChildren.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/metadata/MDChildren.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/metadata/MDValidator.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/metadata/MDValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/metadata/rules/md_adlregRules.xml
+++ b/scorm-impl/adl/src/java/org/adl/validator/metadata/rules/md_adlregRules.xml
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM ADL Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <rules type="metadata" appprof="adlreg">
 
    <!-- Revisit - are Best Practice Vocabularies treated as they were in SCORM 2nd Edition -->

--- a/scorm-impl/adl/src/java/org/adl/validator/sequence/ObjectiveMap.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/sequence/ObjectiveMap.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/sequence/SequenceValidator.java
+++ b/scorm-impl/adl/src/java/org/adl/validator/sequence/SequenceValidator.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/adl/validator/sequence/rules/sequenceRules.xml
+++ b/scorm-impl/adl/src/java/org/adl/validator/sequence/rules/sequenceRules.xml
@@ -1,4 +1,23 @@
 <!--
+  #%L
+  SCORM ADL Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<!--
 ******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/client/ServletProxy.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/client/ServletProxy.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_Operation.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_Operation.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_Servlet.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_Servlet.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_ServletRequest.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_ServletRequest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_ServletResponse.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/SSP_ServletResponse.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/Bucket.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/Bucket.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketAllocation.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketAllocation.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketCollectionManagerInterface.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketCollectionManagerInterface.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketManagerInterface.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketManagerInterface.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketState.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/BucketState.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/ManagedBucket.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/ManagedBucket.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/Persistence.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/Persistence.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/StatusInfo.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/StatusInfo.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/SuccessStatus.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/server/bucket/SuccessStatus.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/java/org/ims/ssp/samplerte/util/SSP_DBHandler.java
+++ b/scorm-impl/adl/src/java/org/ims/ssp/samplerte/util/SSP_DBHandler.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you

--- a/scorm-impl/adl/src/test/org/adl/datamodels/ieee/SCORM_2004_DMTest.java
+++ b/scorm-impl/adl/src/test/org/adl/datamodels/ieee/SCORM_2004_DMTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM ADL Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.adl.datamodels.ieee;
 
 import junit.framework.TestCase;

--- a/scorm-impl/client/src/java/org/sakaiproject/scorm/client/impl/ScormClientHttpAccess.java
+++ b/scorm-impl/client/src/java/org/sakaiproject/scorm/client/impl/ScormClientHttpAccess.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Client Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.client.impl;
 
 import java.io.IOException;

--- a/scorm-impl/content/pom.xml
+++ b/scorm-impl/content/pom.xml
@@ -92,6 +92,18 @@
                     </systemProperties>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/BaseResourceType.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/BaseResourceType.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.util.ArrayList;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/CompressedResourceType.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/CompressedResourceType.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.util.ArrayList;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/FastZipCHH.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/FastZipCHH.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.io.ByteArrayInputStream;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ScormCHH.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ScormCHH.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.io.ByteArrayInputStream;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ScormCollectionType.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ScormCollectionType.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.util.ArrayList;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/VirtualFileSystem.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/VirtualFileSystem.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.io.Serializable;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipCHH.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipCHH.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.io.ByteArrayInputStream;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipCollectionType.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipCollectionType.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.util.ArrayList;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipReader.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipReader.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipWriter.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ZipWriter.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.impl;
 
 import java.io.IOException;

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/spring-sakai-chh.xml
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/spring-sakai-chh.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Content Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/content/src/test/org/sakaiproject/scorm/content/test/VirtualFileSystemTest.java
+++ b/scorm-impl/content/src/test/org/sakaiproject/scorm/content/test/VirtualFileSystemTest.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.test;
 
 import java.util.List;

--- a/scorm-impl/content/src/test/org/sakaiproject/scorm/content/test/ZipWriterTest.java
+++ b/scorm-impl/content/src/test/org/sakaiproject/scorm/content/test/ZipWriterTest.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Content Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.content.test;
 
 import java.io.FileInputStream;

--- a/scorm-impl/content/src/test/resources/applicationContext.xml
+++ b/scorm-impl/content/src/test/resources/applicationContext.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Content Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/model/pom.xml
+++ b/scorm-impl/model/pom.xml
@@ -129,5 +129,19 @@
                 </includes>
             </testResource>
         </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/ActivityTreeHolderDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/ActivityTreeHolderDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import java.util.List;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/AttemptDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/AttemptDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import java.sql.SQLException;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/ContentPackageDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/ContentPackageDaoImpl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import java.util.List;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/ContentPackageManifestDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/ContentPackageManifestDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import java.io.Serializable;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/DataManagerDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/DataManagerDaoImpl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import java.util.Date;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/SeqActivityDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/SeqActivityDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import java.util.List;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/SeqActivityTreeDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/SeqActivityTreeDaoImpl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import java.util.List;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/spring-hibernate-daos.xml
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/spring-hibernate-daos.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Model Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN"
 	"http://www.springframework.org/dtd/spring-beans.dtd">
 

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/spring-hibernate-hbms.xml
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/spring-hibernate-hbms.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Model Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN"
 	"http://www.springframework.org/dtd/spring-beans.dtd">
 

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/MockLearnerDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/MockLearnerDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.sakai;
 
 import java.util.ArrayList;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/SakaiActivityTreeDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/SakaiActivityTreeDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.sakai;
 
 import java.io.ByteArrayInputStream;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/SakaiLearnerDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/SakaiLearnerDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.sakai;
 
 import java.util.ArrayList;

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/spring-mock-daos.xml
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/spring-mock-daos.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Model Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/spring-sakai-daos.xml
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/spring-sakai-daos.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Model Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/spring-sakai-hbms.xml
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/sakai/spring-sakai-hbms.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Model Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN"
 	"http://www.springframework.org/dtd/spring-beans.dtd">
 

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/standalone/StandaloneActivityTreeDaoImpl.java
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/standalone/StandaloneActivityTreeDaoImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.standalone;
 
 import java.io.File;

--- a/scorm-impl/model/src/sql/SCO-80_mysql.sql
+++ b/scorm-impl/model/src/sql/SCO-80_mysql.sql
@@ -1,1 +1,20 @@
+---
+-- #%L
+-- SCORM Model Impl
+-- %%
+-- Copyright (C) 2007 - 2016 Sakai Project
+-- %%
+-- Licensed under the Educational Community License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--             http://opensource.org/licenses/ecl2
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- #L%
+---
 ALTER TABLE SCORM_ELEMENT_T CHANGE COLUMN `VALUE` `VALUE` TEXT NULL DEFAULT NULL ;

--- a/scorm-impl/model/src/test/hibernate-test.xml
+++ b/scorm-impl/model/src/test/hibernate-test.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Model Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/model/src/test/hibernate.properties
+++ b/scorm-impl/model/src/test/hibernate.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Model Impl
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 hibernate.connection.driver_class=org.hsqldb.jdbcDriver
 
 hibernate.connection.url=jdbc:hsqldb:mem:scormplayer

--- a/scorm-impl/model/src/test/org/sakaiproject/scorm/dao/hibernate/AbstractServiceTest.java
+++ b/scorm-impl/model/src/test/org/sakaiproject/scorm/dao/hibernate/AbstractServiceTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /**
  * Copyright Edia 2010. All rights reserved.
  */

--- a/scorm-impl/model/src/test/org/sakaiproject/scorm/dao/hibernate/DataManagerDaoImplTest.java
+++ b/scorm-impl/model/src/test/org/sakaiproject/scorm/dao/hibernate/DataManagerDaoImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Model Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.dao.hibernate;
 
 import org.adl.datamodels.DMErrorCodes;

--- a/scorm-impl/pack/pom.xml
+++ b/scorm-impl/pack/pom.xml
@@ -72,4 +72,21 @@
             <scope>runtime</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/scorm-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/scorm-impl/pack/src/webapp/WEB-INF/components.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Pack
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/pack/src/webapp/WEB-INF/spring-sakai-content.xml
+++ b/scorm-impl/pack/src/webapp/WEB-INF/spring-sakai-content.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Pack
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/pack/src/webapp/WEB-INF/spring-standalone-webapp.xml
+++ b/scorm-impl/pack/src/webapp/WEB-INF/spring-standalone-webapp.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Pack
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/service/pom.xml
+++ b/scorm-impl/service/pom.xml
@@ -100,5 +100,19 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/scorm-impl/service/src/bundle/messages.properties
+++ b/scorm-impl/service/src/bundle/messages.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Service Impl
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 # UI messages
 authFailMsg=You do not have permission to launch SCORM modules in this site.
 

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/adl/impl/ADLConsultantImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/adl/impl/ADLConsultantImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.adl.impl;
 
 import org.adl.datamodels.IDataManager;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/adl/impl/spring-adl-services.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/adl/impl/spring-adl-services.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Service Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/MockScormEntityProviderImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/MockScormEntityProviderImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.entity;
 
 /**

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/ScormEntityProviderImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/ScormEntityProviderImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.entity;
 
 import java.io.IOException;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/navigation/impl/NavigationEvent.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/navigation/impl/NavigationEvent.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.navigation.impl;
 
 import org.sakaiproject.scorm.navigation.INavigationEvent;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/AbstractResourceService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/AbstractResourceService.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.impl;
 
 import java.io.IOException;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.impl;
 
 import java.util.Date;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormContentServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormContentServiceImpl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.impl;
 
 import java.io.File;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.impl;
 
 import java.util.HashMap;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormSequencingServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormSequencingServiceImpl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.impl;
 
 import javax.swing.tree.TreeModel;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Service Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/CHHResourceService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/CHHResourceService.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.sakai.impl;
 
 import org.apache.commons.logging.Log;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/ContentPackageSakaiResource.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/ContentPackageSakaiResource.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.sakai.impl;
 
 import java.io.InputStream;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/MockLearningManagementSystem.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/MockLearningManagementSystem.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.sakai.impl;
 
 import org.sakaiproject.scorm.api.ScormConstants;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiResourceService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiResourceService.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.sakai.impl;
 
 import java.io.ByteArrayOutputStream;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiStatefulService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiStatefulService.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.sakai.impl;
 
 import org.apache.commons.logging.Log;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/spring-mock-services.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/spring-mock-services.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Service Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/spring-sakai-content.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/spring-sakai-content.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Service Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/spring-sakai-services.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/spring-sakai-services.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Service Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/standalone/impl/ContentPackageFile.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/standalone/impl/ContentPackageFile.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.service.standalone.impl;
 
 import java.io.File;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/standalone/impl/StandaloneResourceService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/standalone/impl/StandaloneResourceService.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Service Impl
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.service.standalone.impl;
 
 import java.io.File;

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/standalone/impl/spring-standalone-content.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/standalone/impl/spring-standalone-content.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Service Impl
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-tool/pom.xml
+++ b/scorm-tool/pom.xml
@@ -187,6 +187,18 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.1.1</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/scorm-tool/src/bundle/org/adl/util/messages.properties
+++ b/scorm-tool/src/bundle/org/adl/util/messages.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 ################################################################################
 ## 
 ## Advanced Distributed Learning Co-Laboratory (ADL Co-Lab) Hub grants you 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/AbsoluteUrl.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/AbsoluteUrl.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui;
 
 import javax.servlet.http.HttpServletRequest;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/ContentPackageResourceMountStrategy.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/ContentPackageResourceMountStrategy.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * The logic in this class was modeled after the Apache Wicket class
  * 	org.apache.wicket.request.target.coding.SharedResourceRequestTargetUrlCodingStrategy

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/ContentPackageResourceRequestTarget.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/ContentPackageResourceRequestTarget.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * The logic in this class was modeled after the Apache Wicket class
  * 	org.apache.wicket.request.target.resource.SharedResourceRequestTarget

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/Icon.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/Icon.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui;
 
 import org.apache.wicket.ResourceReference;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/NameValuePair.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/NameValuePair.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui;
 
 import java.io.Serializable;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/ResourceNavigator.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/ResourceNavigator.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui;
 
 import java.io.Serializable;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/UISynchronizer.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/UISynchronizer.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/UISynchronizerPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/UISynchronizerPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui;
 
 import org.apache.wicket.markup.html.WebMarkupContainer;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AccessStatusColumn.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AccessStatusColumn.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberAction.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberAction.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import org.apache.wicket.Component;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<div wicket:id="attemptNumberLinks">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import org.apache.wicket.PageParameters;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberPanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AttemptNumberPanel.properties
@@ -1,1 +1,20 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 attempt.number.title.label = Attempt Number 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/BreadcrumbPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/BreadcrumbPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<div wicket:id="breadcrumbList">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/BreadcrumbPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/BreadcrumbPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import org.apache.wicket.PageParameters;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/ContentPackageDetailPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/ContentPackageDetailPanel.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <wicket:panel>
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/ContentPackageDetailPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/ContentPackageDetailPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import org.apache.wicket.markup.html.basic.Label;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/ContentPackageDetailPanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/ContentPackageDetailPanel.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 label.package.name = Name
 label.open.date = Open 
 label.due.date = Due 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/DecoratedDatePropertyColumn.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/DecoratedDatePropertyColumn.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import java.text.SimpleDateFormat;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/FileUploadForm.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/FileUploadForm.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 # Form properties for UploadForm
 fileToUploadLabel = File To Upload
 displayNameLabel = Name

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/NotificationPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/NotificationPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import org.apache.wicket.feedback.IFeedbackMessageFilter;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.html
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import org.apache.wicket.feedback.IFeedbackMessageFilter;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/StatusColumn.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/StatusColumn.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import java.util.Date;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/TypeAwareCompoundPropertyModel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/TypeAwareCompoundPropertyModel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.components;
 
 import java.text.SimpleDateFormat;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/res/ActionPanel.css
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/res/ActionPanel.css
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /* scorm.css : Styles for scorm console */
 div.actionList {
 	color:#888888;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.pages;
 
 import org.apache.wicket.PageParameters;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 link.list     = List
 link.upload   = Upload

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage_nl.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage_nl.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 link.list     = Lijst
 link.upload   = Uploaden

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.css
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.css
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 	dl dt {
 		font-size: 1.35em;
 		font-weight: bold;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.pages;
 
 import java.util.Properties;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 column.action.edit.label           = Configure
 column.action.grade.label          = Results

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage_nl.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/DisplayDesignatedPackage_nl.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 column.action.edit.label           = Configureren
 column.action.grade.label          = Resultaten

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/MaydayWebMarkupContainer.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/MaydayWebMarkupContainer.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.pages;
 
 import org.apache.wicket.markup.html.WebMarkupContainer;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/NotConfiguredPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/NotConfiguredPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/NotConfiguredPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/NotConfiguredPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.pages;
 
 import org.apache.commons.logging.Log;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/NotConfiguredPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/NotConfiguredPage.properties
@@ -1,2 +1,21 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = This tool is not configured
 designated.resource.notfound = This SCORM player is NOT YET configured to play a designated package. Please edit to the tool properties and configure the property named ${configProperty}

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.pages;
 
 import java.io.Serializable;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 form.instructions.accept.until        = The content package can no longer be played after this close date.
 form.instructions.open.date           = Students won't see this content package until this open date.

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.pages;
 
 import java.util.LinkedList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Learning Content Packages
 table.caption = List of modules
 column.header.content.package.name = Package Name

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage_nl.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage_nl.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 column.action.edit.label           = Configureer
 column.action.grade.label          = Resultaten

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.console.pages;
 
 import java.util.LinkedList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Remove Module
 page.submit = Remove
 page.cancel = Cancel

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/res/management-functions.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/res/management-functions.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 // Scorm Management Functions Namespace
 if (typeof(ScormManageFunctions) == "undefined")
 	ScormManageFunctions = { };

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/res/scorm_console.css
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/res/scorm_console.css
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 		.pageIcon {
 			vertical-align:middle;
 		}

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/headscripts.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/headscripts.js
@@ -1,23 +1,23 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
+
 // set the parent iframe's height to hold our entire contents
 function setMainFrameHeight(id)
 {

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/HibernateFilter.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/HibernateFilter.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player;
 
 import org.hibernate.FlushMode;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormSecurityAdvisor.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormSecurityAdvisor.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player;
 
 import org.apache.commons.logging.Log;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormSecurityFilter.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormSecurityFilter.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player;
 
 import java.io.IOException;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player;
 
 import java.util.List;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/ScormTool.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 paging.display.before = show 
 paging.display.after = items per page
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/SingleScormPackageApplication.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/SingleScormPackageApplication.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player;
 
 import java.util.Properties;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/SingleScormPackageApplication.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/SingleScormPackageApplication.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 paging.display.before = show 
 paging.display.after = items per page
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/ActivityAjaxEventBehavior.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/ActivityAjaxEventBehavior.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.behaviors;
 
 import org.apache.wicket.ajax.AjaxEventBehavior;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/CloseWindowBehavior.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/CloseWindowBehavior.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.behaviors;
 
 import org.apache.commons.logging.Log;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/SCORM13API.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/SCORM13API.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.behaviors;
 
 import org.adl.api.ecmascript.SCORM13APIInterface;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/SjaxCall.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/SjaxCall.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.behaviors;
 
 import java.lang.reflect.Method;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/res/scorm-sjax.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/behaviors/res/scorm-sjax.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 // Scorm Sjax Namespace
 if (typeof(ScormSjax) == "undefined")
 	ScormSjax = { };

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ActivityAjaxButton.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ActivityAjaxButton.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import org.apache.commons.logging.Log;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ActivityTree.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ActivityTree.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import java.io.Serializable;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/AdminPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/AdminPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/AdminPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/AdminPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import java.io.Serializable;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ButtonForm.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ButtonForm.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import org.adl.sequencer.SeqNavRequests;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ChoicePanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ChoicePanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 <div>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ChoicePanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/ChoicePanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import org.adl.sequencer.SeqNavRequests;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/CommunicationPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/CommunicationPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<div wicket:id="sjaxContainer">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/CommunicationPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/CommunicationPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import java.util.List;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/DeniedPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/DeniedPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<h4>Access Denied</h4>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/DeniedPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/DeniedPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import org.apache.wicket.markup.html.panel.Panel;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LaunchPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LaunchPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
     <div id="scormMainPanel">
         <div id="scormNavPanel">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LaunchPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LaunchPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LazyLaunchPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LazyLaunchPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import java.util.List;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LazyLoadPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LazyLoadPanel.html
@@ -1,1 +1,20 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel><div wicket:id="content"></div></wicket:panel>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LazyLoadPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/LazyLoadPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * This code is copied and slightly modified from the Apache Wicket project class
  * 	org.apache.wicket.extensions.ajax.markup.html.AjaxLazyLoadPanel

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/SjaxContainer.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/SjaxContainer.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import org.apache.commons.logging.Log;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/TreePanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/TreePanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 	<div wicket:id="tree" class="my-tree"></div>
 </wicket:panel>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/TreePanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/TreePanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.components;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/res/API.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/res/API.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 
 
 function APIAdapter() { };

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/res/APIWrapper.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/res/APIWrapper.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** FileName: APIWrapper.js

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/res/scorm-sjax.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/components/res/scorm-sjax.js
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * This code borrows heavily from the Apache Wicket project file wicket-ajax.js
  *   authored by Igor Vaynberg and Matej Knopp and licensed under the following license:

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/decorators/SjaxCallDecorator.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/decorators/SjaxCallDecorator.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.decorators;
 
 import org.apache.wicket.ajax.IAjaxCallDecorator;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/BaseToolPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/BaseToolPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"  
       xmlns:wicket="http://wicket.sourceforge.net/"

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/BaseToolPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/BaseToolPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.pages;
 
 import org.apache.wicket.markup.html.IHeaderContributor;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/CompletionPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/CompletionPage.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:extend>
 	<h3>SCORM Session Complete</h3>
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/CompletionPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/CompletionPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.pages;
 
 import org.apache.wicket.PageParameters;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/FilePickerPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/FilePickerPage.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:extend>
 
 Click <a href="#" wicket:id="sendToHelper">here</a>!

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/FilePickerPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/FilePickerPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.pages;
 
 import java.util.List;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/NotificationPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/NotificationPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <head>
 </head>
 <wicket:extend>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/NotificationPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/NotificationPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.pages;
 
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/PlayerPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/PlayerPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <head>
 	<title>SCORM Content</title>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/PlayerPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/PlayerPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.pages;
 
 import javax.servlet.http.HttpServletRequest;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/res/API.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/res/API.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 
 
 function APIAdapter() { };

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/res/APIWrapper.js
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/pages/res/APIWrapper.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** FileName: APIWrapper.js

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/CompressingContentPackageResourceStream.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/CompressingContentPackageResourceStream.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * This code borrows substantially from the Apache Wicket nested class
  *  	org.apache.wicket.markup.html.CompressedPackageResource$CompressingResourceStream

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/ContentPackageResourceStream.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/ContentPackageResourceStream.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.util;
 
 import java.io.IOException;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/ContentPackageWebResource.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/ContentPackageWebResource.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.util;
 
 import org.apache.wicket.Application;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/Utils.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/player/util/Utils.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.util;
 
 import java.util.ArrayList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ActivityReportPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ActivityReportPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 		<h4><span wicket:id="title"></span></h4>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ActivityReportPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ActivityReportPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import java.util.ArrayList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ActivityReportPanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ActivityReportPanel.properties
@@ -1,1 +1,20 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 activity.title.label = Activity: 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIDataGraph.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIDataGraph.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<table wicket:id="attemptTable" class="listHier lines nolines">			

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIDataGraph.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIDataGraph.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import java.util.LinkedList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIDataGraph.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIDataGraph.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 table.caption = List of data
 table.summary = List of data

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldGroupPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldGroupPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<div wicket:id="fields">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldGroupPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldGroupPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import java.util.List;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 			<p class="shorttext">
 				<label for="fieldValue">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/CMIFieldPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import org.apache.wicket.markup.html.WebMarkupContainer;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <html>
 <head>
 	<style>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import org.apache.wicket.ResourceReference;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/InteractionPanel.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 id.label = Identifier
 type.label = Type
 description.label = Description:

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <wicket:panel>
 			<h4><wicket:message key="label.title"/></h4>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import org.apache.wicket.markup.html.basic.Label;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/LearnerDetailsPanel.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 label.learner.name = Name
 label.learner.id = Id
 label.title = Learner details

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<div wicket:id="objectivesView" style="margin: 10px;border: 1px solid lightgray;">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import java.util.List;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ObjectivesPanel.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 success.status.label = Objective Success Status
 completion.status.label = Objective Completion Status
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 		<div wicket:id="percentComplete"></div>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import org.apache.wicket.markup.html.basic.Label;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ProgressPanel.properties
@@ -1,2 +1,21 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 success.status.label = Success Status
 completion.status.label = Completion Status

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ScorePanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ScorePanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<div>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ScorePanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ScorePanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import org.apache.wicket.markup.html.basic.Label;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ScorePanel.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/ScorePanel.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 
 scaled.score.label = Score (scaled): 
 raw.score.label = Raw Score: 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/SummaryPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/components/SummaryPanel.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.components;
 
 import org.apache.wicket.markup.html.panel.Panel;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/BaseResultsPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/BaseResultsPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/BaseResultsPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/BaseResultsPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.pages;
 
 import org.apache.commons.logging.Log;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.util.LinkedList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/InteractionResultsPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Results by Learner, Module, and Interaction
 
 # SCO-94

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.util.LinkedList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/LearnerResultsPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Results by Learner
 page.instructions = 
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.io.ByteArrayInputStream;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Results
 sakai.scorm.singlepackage.tool.title=Results
 page.instructions = Select a learner name from the list below to view results for that individual

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.pages;
 
 import java.util.ArrayList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ScoResultsPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Results by Learner and Module
 
 # SCO-94

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/InteractionProvider.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/InteractionProvider.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.util;
 
 import java.util.Collections;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/ObjectiveProvider.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/ObjectiveProvider.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.util;
 
 import java.util.Iterator;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/SummaryProvider.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/util/SummaryProvider.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.reporting.util;
 
 import java.util.Collections;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/components/FileUploadForm.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/components/FileUploadForm.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * Contains code copied from org.apache.wicket.examples.upload.UploadPage, 
  * authored by Eelco Hillenius, and originally licensed under the following

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/ConfirmPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/ConfirmPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"  
       xmlns:wicket="http://wicket.sourceforge.net/"
       xmlns:wairole="http://www.w3.org/2005/01/wai-rdf/GUIRoleTaxonomy#"

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/ConfirmPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/ConfirmPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.upload.pages;
 
 import org.apache.wicket.PageParameters;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/ConfirmPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/ConfirmPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Confirm
 
 archive.title = File 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml"  
       xmlns:wicket="http://wicket.sourceforge.net/"
       xmlns:wairole="http://www.w3.org/2005/01/wai-rdf/GUIRoleTaxonomy#"

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.upload.pages;
 
 import java.util.Arrays;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Upload Learning Content Package
 page.instructions = Click on the "Browse" button below to select a file for upload. \
 					This file should be formatted as a zip archive (.zip file) and should \

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/validation/pages/ValidationPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/validation/pages/ValidationPage.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <head>
 	<wicket:head>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/validation/pages/ValidationPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/validation/pages/ValidationPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.validation.pages;
 
 import java.util.LinkedList;

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/validation/pages/ValidationPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/validation/pages/ValidationPage.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 page.title = Validate Learning Content Packages
 table.caption = List of potential content packages
 table.summary = List of potential content packages

--- a/scorm-tool/src/java/org/sakaiproject/wicket/tool/SakaiWicketServlet.java
+++ b/scorm-tool/src/java/org/sakaiproject/wicket/tool/SakaiWicketServlet.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.wicket.tool;
 
 import java.io.IOException;

--- a/scorm-tool/src/test/hibernate-test.xml
+++ b/scorm-tool/src/test/hibernate-test.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-tool/src/test/hibernate.properties
+++ b/scorm-tool/src/test/hibernate.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Tool
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 hibernate.connection.driver_class=org.hsqldb.jdbcDriver
 
 hibernate.connection.url=jdbc:hsqldb:mem:scormplayer

--- a/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/AbstractSCORM13APBase.java
+++ b/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/AbstractSCORM13APBase.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.behaviors;
 
 import org.adl.api.ecmascript.APIErrorManager;

--- a/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/SCORM13APITest.java
+++ b/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/SCORM13APITest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.scorm.ui.player.behaviors;
 
 import org.junit.Assert;

--- a/scorm-tool/src/webapp/WEB-INF/applicationContext.xml
+++ b/scorm-tool/src/webapp/WEB-INF/applicationContext.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">

--- a/scorm-tool/src/webapp/WEB-INF/web.xml
+++ b/scorm-tool/src/webapp/WEB-INF/web.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <web-app id="SCORMPlayerWebApp" version="2.4" 
     xmlns="http://java.sun.com/xml/ns/j2ee" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/scorm-tool/src/webapp/index.jsp
+++ b/scorm-tool/src/webapp/index.jsp
@@ -1,3 +1,22 @@
+<%--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
 <html>
 
 <body>

--- a/scorm-tool/src/webapp/scripts/APIWrapper.js
+++ b/scorm-tool/src/webapp/scripts/APIWrapper.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /*******************************************************************************
 **
 ** FileName: APIWrapper.js

--- a/scorm-tool/src/webapp/scripts/resize.js
+++ b/scorm-tool/src/webapp/scripts/resize.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 function initResizing() {
 	onResize();
 }

--- a/scorm-tool/src/webapp/scripts/scorm.js
+++ b/scorm-tool/src/webapp/scripts/scorm.js
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 <script language=javascript>
 /****************************************************************************
 **

--- a/scorm-tool/src/webapp/styles/scorm.css
+++ b/scorm-tool/src/webapp/styles/scorm.css
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Tool
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /* scorm.css : Styles for scorm player */
 body, div {
     margin: 0px;

--- a/scorm-tool/src/webapp/tools/sakai.scorm.singlepackage.tool.xml
+++ b/scorm-tool/src/webapp/tools/sakai.scorm.singlepackage.tool.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <registration>
 	<tool id="sakai.scorm.singlepackage.tool" title="SCORM Player for a Single Package"
 		description="Used to play a single SCORM package per placement">

--- a/scorm-tool/src/webapp/tools/sakai.scorm.tool.xml
+++ b/scorm-tool/src/webapp/tools/sakai.scorm.tool.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0"?>
+<!--
+  #%L
+  SCORM Tool
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <registration>
 	<tool id="sakai.scorm.tool" title="SCORM Player"
 		description="For playing SCORM content">

--- a/wicket-tool/pom.xml
+++ b/wicket-tool/pom.xml
@@ -90,6 +90,20 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check-file-header</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <repositories>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/form/AjaxRolloverImageButton.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/form/AjaxRolloverImageButton.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.ajax.markup.html.form;
 
 import org.apache.wicket.AttributeModifier;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/form/res/ajax-image-button-rollover.js
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/form/res/ajax-image-button-rollover.js
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 
 // Wicket Namespace -- we need to ensure that some stuff is there before we proceed -- this top block of code is borrowed
 // from the wicket-ajax.js file under the Apache Wicket project - copyright above does not apply

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/filter/FilterPanel.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/filter/FilterPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 	<form wicket:id="filterForm">
 		<p class="instruction"><wicket:message key="filter.showing"/></p>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/filter/FilterPanel.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/filter/FilterPanel.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.ajax.markup.html.navigation.filter;
 
 import java.util.List;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/ClassicPagingNavigator.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/ClassicPagingNavigator.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <html xmlns:wicket>
 <body>
 	<wicket:panel>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/ClassicPagingNavigator.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/ClassicPagingNavigator.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 /*
  * This code has borrowed extensively from the Apache Wicket class
  * 	org.apache.wicket.markup.html.navigation.paging.PagingNavigator,

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/ClassicPagingNavigator.properties
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/ClassicPagingNavigator.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Wicket Toolset
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 button.pager.first = First
 button.pager.first.value = |&lt
 button.pager.last = Last

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/PagingChoiceRenderer.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/PagingChoiceRenderer.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.ajax.markup.html.navigation.paging;
 
 import org.apache.wicket.markup.html.form.IChoiceRenderer;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/PagingNavigationButton.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/PagingNavigationButton.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 /* This code is a port of the Apache Wicket class 
  * 	org.apache.wicket.markup.html.navigation.paging.PagingNavigationLink
  * that uses a Button rather than a Link. 

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/PagingNavigationIncrementButton.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/paging/PagingNavigationIncrementButton.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.ajax.markup.html.navigation.paging;
 
 import org.apache.wicket.Page;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/search/SearchPanel.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/search/SearchPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 
 	<form wicket:id="searchForm" class="inlineForm">

--- a/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/search/SearchPanel.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/ajax/markup/html/navigation/search/SearchPanel.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.ajax.markup.html.navigation.search;
 
 import org.apache.wicket.markup.html.form.Button;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiPortletWebPage.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiPortletWebPage.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <html  
       xmlns="http://www.w3.org/1999/xhtml"  
       xmlns:wicket="http://wicket.sourceforge.net/"  

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiPortletWebPage.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiPortletWebPage.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html;
 
 import org.apache.wicket.Component;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiSessionExpiredPage.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiSessionExpiredPage.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:extend>
 	<h3>Session Expired</h3>
 	

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiSessionExpiredPage.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/SakaiSessionExpiredPage.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html;
 
 public class SakaiSessionExpiredPage extends SakaiPortletWebPage {

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/fckeditor/FCKEditorPanel.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/fckeditor/FCKEditorPanel.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <!-- Copyright (c) 2006. Centre for e-Science. Lancaster University. United Kingdom. 
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/fckeditor/FCKEditorPanel.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/fckeditor/FCKEditorPanel.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.fckeditor;
 
 import java.util.Map;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/fckeditor/FCKEditorScript.js
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/fckeditor/FCKEditorScript.js
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 <script type="text/javascript" language="JavaScript">
 	function setupEditor(textarea_id)
 	{

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/form/CancelButton.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/form/CancelButton.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.form;
 
 import org.apache.wicket.Page;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/AjaxIconLink.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/AjaxIconLink.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 	<a href="#" wicket:id="link"><img wicket:id="linkIcon"/></a>
 </wicket:panel>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/AjaxIconLink.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/AjaxIconLink.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.link;
 
 import org.apache.wicket.ResourceReference;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/BookmarkablePageLabeledLink.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/BookmarkablePageLabeledLink.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.link;
 
 import org.apache.wicket.PageParameters;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/IconLink.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/IconLink.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 	<a href="#" wicket:id="link"><img wicket:id="linkIcon"/></a>
 </wicket:panel>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/IconLink.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/IconLink.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.link;
 
 import org.apache.wicket.PageParameters;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/NavIntraLink.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/link/NavIntraLink.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.link;
 
 import org.apache.wicket.Page;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/ClassicDataPresenter.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/ClassicDataPresenter.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 	
 	<span wicket:id="exteriorToolbars">

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/ClassicDataPresenter.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/ClassicDataPresenter.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * This file contains code copied from the Apache Wicket project, from the classes
  *  org.apache.wicket.extensions.markup.html.repeater.data.table.DataTable

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/ClassicDataPresenter.properties
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/ClassicDataPresenter.properties
@@ -1,2 +1,21 @@
+###
+# #%L
+# SCORM Wicket Toolset
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 table.summary = Summary
 table.caption = Caption

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/EnhancedDataPresenter.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/presenter/EnhancedDataPresenter.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.presenter;
 
 import java.util.LinkedList;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/Action.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/Action.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import java.io.Serializable;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ActionColumn.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ActionColumn.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import java.util.LinkedList;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ActionPanel.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ActionPanel.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <wicket:panel>
 <h4><a wicket:id="action"></a></h4>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ActionPanel.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ActionPanel.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import java.util.ArrayList;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/AjaxImageLinkColumn.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/AjaxImageLinkColumn.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import org.apache.wicket.ResourceReference;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicDataTable.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicDataTable.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <wicket:panel>
 <caption class="skip" style="display:none" wicket:id="caption"></caption>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicDataTable.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicDataTable.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * This file contains code copied from the Apache Wicket project, from the class
  *  org.apache.wicket.extensions.markup.html.repeater.data.table.DefaultDataTable

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicHeadersToolbar.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicHeadersToolbar.html
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <wicket:panel>
 	<tr class="headers">

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicHeadersToolbar.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/BasicHeadersToolbar.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 /*
  * This file contains code copied from the Apache Wicket project, from the class
  *  org.apache.wicket.extensions.markup.html.repeater.data.table.HeadersToolbar

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigationToolbar.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigationToolbar.html
@@ -18,6 +18,26 @@
    limitations under the License.
 -->
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <wicket:panel>
 	<tr class="navigation">

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigationToolbar.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigationToolbar.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 /* This code borrows its structure and organization from the Apache Wicket class
  *  org.apache.wicket.extensions.markup.html.repeater.data.table.NavigationToolbar
  * authored by Igor Vaynberg (ivaynberg) and licensed under the license copied

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigatorLabel.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigatorLabel.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import org.apache.wicket.IClusterable;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigatorLabel.properties
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ClassicNavigatorLabel.properties
@@ -1,3 +1,22 @@
+###
+# #%L
+# SCORM Wicket Toolset
+# %%
+# Copyright (C) 2007 - 2016 Sakai Project
+# %%
+# Licensed under the Educational Community License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#             http://opensource.org/licenses/ecl2
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 paging.display.viewing = Viewing
 paging.display.to = to
 paging.display.of = of

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/DecoratedPropertyColumn.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/DecoratedPropertyColumn.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.table.PropertyColumn;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/EnhancedNavigationToolbar.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/EnhancedNavigationToolbar.html
@@ -1,3 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <!-- 
    Modified, originally copied this from the Apache Wicket project NavigationToolbar.html,
    which was licensed under the following license:
@@ -17,7 +37,6 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.sourceforge.net/" xml:lang="en" lang="en">
 <wicket:panel>
 	<tr class="navigation">

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/EnhancedNavigationToolbar.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/EnhancedNavigationToolbar.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import org.apache.wicket.Component;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ExternalAction.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ExternalAction.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import org.apache.wicket.AttributeModifier;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ImageLinkColumn.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/ImageLinkColumn.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.table;
 
 import org.apache.wicket.PageParameters;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/res/ActionPanel.css
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/table/res/ActionPanel.css
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *             http://opensource.org/licenses/ecl2
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 /* CSS for ActionPanel */
 .actionList {
 	color:#888888;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/toolbar/NavIntraToolbar.html
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/toolbar/NavIntraToolbar.html
@@ -1,3 +1,22 @@
+<!--
+  #%L
+  SCORM Wicket Toolset
+  %%
+  Copyright (C) 2007 - 2016 Sakai Project
+  %%
+  Licensed under the Educational Community License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+              http://opensource.org/licenses/ecl2
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
 <wicket:panel>
 	<div id="header" class="navIntraTool" wicket:id="items">
 	    <a href="#" wicket:id="link"></a>

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/toolbar/NavIntraToolbar.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/data/toolbar/NavIntraToolbar.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.data.toolbar;
 
 import org.apache.wicket.markup.html.WebMarkupContainer;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/util/EnhancedDataProvider.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/util/EnhancedDataProvider.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.markup.html.repeater.util;
 
 import java.io.Serializable;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/util/SortableListDataProvider.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/repeater/util/SortableListDataProvider.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 /*
  * This file contains code copied from the Apache Wicket project, from the class
  *  org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider

--- a/wicket-tool/src/java/org/sakaiproject/wicket/model/DecoratedPropertyModel.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/model/DecoratedPropertyModel.java
@@ -1,24 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
-
+ * #L%
+ */
 package org.sakaiproject.wicket.model;
 
 import org.apache.wicket.model.PropertyModel;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/model/SimpleDateFormatPropertyModel.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/model/SimpleDateFormatPropertyModel.java
@@ -1,24 +1,22 @@
-
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.model;
 
 import java.text.SimpleDateFormat;

--- a/wicket-tool/src/java/org/sakaiproject/wicket/protocol/http/SakaiWebApplication.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/protocol/http/SakaiWebApplication.java
@@ -1,23 +1,22 @@
-/**********************************************************************************
- * $URL:  $
- * $Id:  $
- ***********************************************************************************
- *
- * Copyright (c) 2007 The Sakai Foundation.
- * 
- * Licensed under the Educational Community License, Version 1.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+/*
+ * #%L
+ * SCORM Wicket Toolset
+ * %%
+ * Copyright (C) 2007 - 2016 Sakai Project
+ * %%
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.opensource.org/licenses/ecl1.php
+ *             http://opensource.org/licenses/ecl2
  * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- * See the License for the specific language governing permissions and 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **********************************************************************************/
+ * #L%
+ */
 package org.sakaiproject.wicket.protocol.http;
 
 import org.apache.commons.logging.Log;


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-134

Standard ECL 2 license headers should be on all appropriate files:

https://github.com/sakaiproject/ecl-license
