### PR TITLE
SCO-135 fix the trailing divider after the 'Upload' tab in the SCORM navbar

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.html
@@ -40,12 +40,12 @@
 					<a href="#" wicket:id="uploadLink"></a>
 				</span>
 			</li>
-			<li>
+			<!--<li>
 				<span wicket:id="validateContainer">
 					<img wicket:id="validateIcon" class="pageIcon"/>
 					<a href="#" wicket:id="validateLink"></a>
 				</span>
-			</li>
+			</li>-->
 		</ul>
 
 		<wicket:enclosure child="breadcrumbs">

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.java
@@ -84,14 +84,14 @@ public class ConsoleBasePage extends SakaiPortletWebPage implements IHeaderContr
 		
         NavIntraLink listLink = new NavIntraLink("listLink", new ResourceModel("link.list"), PackageListPage.class);
         NavIntraLink uploadLink = new NavIntraLink("uploadLink", new ResourceModel("link.upload"), UploadPage.class);
-        NavIntraLink validateLink = new NavIntraLink("validateLink", new ResourceModel("link.validate"), ValidationPage.class);
+        //NavIntraLink validateLink = new NavIntraLink("validateLink", new ResourceModel("link.validate"), ValidationPage.class);
         
         WebMarkupContainer listContainer = new WebMarkupContainer( "listContainer" );
         WebMarkupContainer uploadContainer = new WebMarkupContainer( "uploadContainer" );
-        WebMarkupContainer validateContainer = new WebMarkupContainer( "validateContainer" );
+        //WebMarkupContainer validateContainer = new WebMarkupContainer( "validateContainer" );
         listContainer.add( listLink );
         uploadContainer.add( uploadLink );
-        validateContainer.add( validateLink );
+        //validateContainer.add( validateLink );
 
         SimpleAttributeModifier className = new SimpleAttributeModifier( "class", "current" );
         if( listLink.linksTo( getPage() ) )
@@ -104,48 +104,48 @@ public class ConsoleBasePage extends SakaiPortletWebPage implements IHeaderContr
             uploadContainer.add( className );
             uploadLink.add( className );
         }
-        else if( validateLink.linksTo( getPage() ) )
-        {
-            validateContainer.add( className );
-            validateLink.add( className );
-        }
+        //else if( validateLink.linksTo( getPage() ) )
+        //{
+        //    validateContainer.add( className );
+        //    validateLink.add( className );
+        //}
         
         listLink.setVisible(canUpload || canValidate);
         uploadLink.setVisible(canUpload);
         
         // SCO-107 - hide the validate link (interface is currently unimplemented)
         //validateLink.setVisible(canValidate);
-        validateLink.setVisibilityAllowed(false);
+        //validateLink.setVisibilityAllowed(false);
         
         Icon listIcon = new Icon("listIcon", LIST_ICON);
         Icon uploadIcon = new Icon("uploadIcon", UPLOAD_ICON);
-        Icon validateIcon = new Icon("validateIcon", VALIDATE_ICON);
+        //Icon validateIcon = new Icon("validateIcon", VALIDATE_ICON);
         
         // SCO-109 - conditionally show the icons in the menu bar buttons
         boolean enableMenuBarIcons = serverConfigurationService.getBoolean( SAK_PROP_ENABLE_MENU_BUTTON_ICONS, true );
         if( enableMenuBarIcons )
         {
-        listIcon.setVisible(canUpload || canValidate);
-        uploadIcon.setVisible(canUpload);
-        
-        // SCO-107 hide the validate link (interface is currently unimplemented)
-        //validateIcon.setVisible(canValidate);
-        validateIcon.setVisibilityAllowed(false);
+            listIcon.setVisible(canUpload || canValidate);
+            uploadIcon.setVisible(canUpload);
+
+            // SCO-107 hide the validate link (interface is currently unimplemented)
+            //validateIcon.setVisible(canValidate);
+            //validateIcon.setVisibilityAllowed(false);
         }
         else
         {
             listIcon.setVisibilityAllowed( false );
             uploadIcon.setVisibilityAllowed( false );
-            validateIcon.setVisibilityAllowed( false );
+            //validateIcon.setVisibilityAllowed( false );
         }
         
         listContainer.add(listIcon);
         uploadContainer.add(uploadIcon);
-        validateContainer.add(validateIcon);
+        //validateContainer.add(validateIcon);
 
         wmc.add( listContainer );
         wmc.add( uploadContainer );
-        wmc.add( validateContainer );
+        //wmc.add( validateContainer );
 
         // add the toolbar container
         add(wmc);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-135

Removing the trailing divider is actually a little weird, because it's actually a border right on the previous item. This is because the 'Validation' link in the navBar has been set to not display because the UI is not implemented.

As such, there's a hidden span in another li after the 'Upload' menu item, and because it's not the last li in the ul, it gets a border right.

Because you cannot tell Wicket to not render a component, the only solution is to comment out this mark-up and corresponding Java code for the "Validate" menu item until it has been implemented. In this way, the "Upload" item becomes the last li in the ul, and therefore does not get a border right from the CSS pseudo class.
