### PR TITLE
SCO-138 update poms to reference master 10.7, update project version to 10.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
         <groupId>org.sakaiproject</groupId>
         <artifactId>master</artifactId>
         <relativePath>../master/pom.xml</relativePath>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
     </parent>
 
     <name>Sakai SCORM Project</name>
     <artifactId>sakai-scorm-base</artifactId>
-    <version>10-SNAPSHOT</version>
+    <version>10.7</version>
     <packaging>pom</packaging>
     <organization>
         <name>Sakai Project</name>
@@ -95,24 +95,6 @@
                     <tagNameFormat>${project.version}</tagNameFormat>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>1.8</version>
-                <configuration>
-                    <licenseName>ecl_v2</licenseName>
-                    <licenseResolver>classpath://org/sakaiproject</licenseResolver>
-                    <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
-
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.sakaiproject.license</groupId>
-                        <artifactId>ecl-license</artifactId>
-                        <version>1.0</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/scorm-api/pom.xml
+++ b/scorm-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -62,19 +62,5 @@
                 </includes>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/scorm-impl/adl/pom.xml
+++ b/scorm-impl/adl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -81,21 +81,4 @@
             <type>jar</type>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/scorm-impl/client/pom.xml
+++ b/scorm-impl/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/scorm-impl/content/pom.xml
+++ b/scorm-impl/content/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -85,18 +85,6 @@
                         </property>
                     </systemProperties>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
         <resources>

--- a/scorm-impl/model/pom.xml
+++ b/scorm-impl/model/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -126,19 +126,5 @@
                 </includes>
             </testResource>
         </testResources>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/scorm-impl/pack/pom.xml
+++ b/scorm-impl/pack/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -69,21 +69,4 @@
             <scope>runtime</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/scorm-impl/service/pom.xml
+++ b/scorm-impl/service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -95,19 +95,5 @@
                 </includes>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/scorm-tool/pom.xml
+++ b/scorm-tool/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -184,18 +184,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.1.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check-file-header</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/wicket-tool/pom.xml
+++ b/wicket-tool/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>sakai-scorm-base</artifactId>
-        <version>10-SNAPSHOT</version>
+        <version>10.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-138

Poms need to be updated to reference master 10.7 instead of 10-SNAPSHOT, bump project version to 10.7
