### PR TITLE
SCO-141 remove validate checkbox on upload ui

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.html
@@ -45,7 +45,8 @@
 						    </p>
 						    <br/>
 						    <p class="longtext">
-						    	<input type="checkbox" wicket:id="fileValidated"/> <span class="instruction"><wicket:message key="upload.validate.checkbox"/></span>
+						    	<input type="checkbox" wicket:id="fileValidated"/>
+						    	<span class="instruction" wicket:id="lblValidate"></span>
 						    </p>
 						    <p class="shorttext">
 						    	<label for="priority" wicket:id="lblPriority"></label>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/pages/UploadPage.java
@@ -19,6 +19,7 @@
  */
 package org.sakaiproject.scorm.ui.upload.pages;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.commons.logging.Log;
@@ -50,6 +51,7 @@ import org.apache.wicket.util.lang.Bytes;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.scorm.api.ScormConstants;
+import org.sakaiproject.scorm.exceptions.ResourceStorageException;
 import org.sakaiproject.scorm.service.api.ScormContentService;
 import org.sakaiproject.scorm.service.api.ScormResourceService;
 import org.sakaiproject.scorm.ui.console.pages.ConsoleBasePage;
@@ -127,7 +129,14 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 			fileUploadField = new FileUploadField( "fileInput" );
 			fileUploadField.add( new AttributeAppender( "onchange", new Model( "document.getElementsByName( \"btnSubmit\" )[0].disabled = this.value === '';" ), ";" ) );
 			add( fileUploadField );
-			add(new CheckBox("fileValidated"));
+
+			// SCO-141 hide the validate checkbox (currently unimplemented)
+			CheckBox validate = new CheckBox( "fileValidated" );
+			validate.setVisibilityAllowed( false );
+			Label lblValidate = new Label( "lblValidate", new ResourceModel( "upload.validate.checkbox" ) );
+			lblValidate.setVisibilityAllowed( false );
+			add( lblValidate );
+			add( validate );
 
 			// SCO-97 sakai.property to enable/disable (show/hide) email sending (drop down)
 			@SuppressWarnings( { "unchecked", "rawtypes" } )
@@ -239,7 +248,7 @@ public class UploadPage extends ConsoleBasePage implements ScormConstants {
 									setResponsePage( ConfirmPage.class, params );
 								}
 							}
-							catch( Exception e )
+							catch( IOException | ResourceStorageException e )
 							{
 								UploadPage.this.warn( getLocalizer().getString( "upload.failed", UploadPage.this, new Model( e ) ) );
 								LOG.error( "Failed to upload file", e );


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-141

The 'Validate' checkbox and label should be hidden from the UI because the validation has never been implemented. This was missed during submission of SCO-107.