### PR TITLE
SCO-156: Setting the open date to the future hides the module from the instructor

### DIFF
--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormContentServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormContentServiceImpl.java
@@ -192,7 +192,7 @@ public abstract class ScormContentServiceImpl implements ScormContentService
 		List<ContentPackage> allPackages = contentPackageDao().find( context );
 		List<ContentPackage> releasedPackages = new LinkedList<>();
 
-		if( lms().canModify( siteID ) )
+		if( lms().canModify( context ) )
 		{
 			return allPackages;
 		}

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
@@ -71,9 +71,9 @@ public class PackageListPage extends ConsoleBasePage
 
 	public PackageListPage(PageParameters params)
 	{
-		List<ContentPackage> contentPackages = contentService.getContentPackages();
-
 		final String context = lms.currentContext();
+		List<ContentPackage> contentPackages = contentService.getContentPackages(context);
+
 		final boolean canConfigure = lms.canConfigure(context);
 		final boolean canGrade = lms.canGrade(context);
 		final boolean canViewResults = lms.canViewResults(context);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-156

Setting the "Open Date" on a module to some date in the future hide's the module on the Package List page from the instructor until the open date has arrived or passed.

This is a logic error, as the instructor user has the necessary permissions, but the permission checks were being passed a null value rather than the actual site ID.