### PR TITLE
SCO-157: due date can be set prior to open date

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.html
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <html xmlns:wicket>
-<body>
-<wicket:panel>
-  <span wicket:id="feedbackul">
-    <span wicket:id="messages" class="errorlevel">
-      <span wicket:id="message" class="errorlevel">A message</span>
-    </span>
-  </span>
-</wicket:panel>
-</body>
+	<body>
+		<wicket:panel>
+			<span wicket:id="feedbackul">
+				<span wicket:id="messages">
+					<span wicket:id="message">A message</span>
+				</span>
+			</span>
+		</wicket:panel>
+	</body>
 </html>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.java
@@ -44,8 +44,8 @@ public class SakaiFeedbackPanel extends FeedbackPanel
 				return "sak-banner-info";
 			case FeedbackMessage.WARNING:
 				return "sak-banner-warn";
+			default:
+				return "sak-banner-error";
 		}
-
-		return "sak-banner-error";
 	}
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/SakaiFeedbackPanel.java
@@ -15,18 +15,37 @@
  */
 package org.sakaiproject.scorm.ui.console.components;
 
+import org.apache.wicket.feedback.FeedbackMessage;
 import org.apache.wicket.feedback.IFeedbackMessageFilter;
 import org.apache.wicket.markup.html.panel.FeedbackPanel;
 
 public class SakaiFeedbackPanel extends FeedbackPanel
 {
-	public SakaiFeedbackPanel(String id, IFeedbackMessageFilter filter)
+	private static final long serialVersionUID = 1L;
+
+	public SakaiFeedbackPanel( String id, IFeedbackMessageFilter filter )
 	{
-		super(id, filter);
+		super( id, filter );
 	}
 
-	public SakaiFeedbackPanel(String id)
+	public SakaiFeedbackPanel( String id )
 	{
-		super(id);
+		super( id );
+	}
+
+	@Override
+	protected String getCSSClass( final FeedbackMessage message )
+	{
+		switch( message.getLevel() )
+		{
+			case FeedbackMessage.SUCCESS:
+				return "sak-banner-success";
+			case FeedbackMessage.INFO:
+				return "sak-banner-info";
+			case FeedbackMessage.WARNING:
+				return "sak-banner-warn";
+		}
+
+		return "sak-banner-error";
 	}
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/ConsoleBasePage.java
@@ -20,7 +20,6 @@ import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.IHeaderContributor;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
@@ -51,7 +50,7 @@ public class ConsoleBasePage extends SakaiPortletWebPage implements IHeaderContr
 	public ToolManager toolManager;
 
 	// The feedback panel component displays dynamic messages to the user
-	protected FeedbackPanel feedback;
+	protected SakaiFeedbackPanel feedback;
 	private BreadcrumbPanel breadcrumbs;
 
 	public NavLink listLink;
@@ -89,8 +88,15 @@ public class ConsoleBasePage extends SakaiPortletWebPage implements IHeaderContr
 		// add the toolbar container
 		add(navBar);
 
+		// page title
 		add(newPageTitleLabel(params));
-		add(feedback = new SakaiFeedbackPanel("feedback"));
+
+		// feedback panel
+		feedback = new SakaiFeedbackPanel("feedback");
+		feedback.setOutputMarkupId(true);
+		add(feedback);
+
+		// breadcrumbs
 		add(breadcrumbs = new BreadcrumbPanel("breadcrumbs"));
 	}
 
@@ -108,8 +114,6 @@ public class ConsoleBasePage extends SakaiPortletWebPage implements IHeaderContr
 	protected void onBeforeRender()
 	{
 		super.onBeforeRender();
-		// If a feedback message exists, then make the feedback panel visible, otherwise, hide it.
-		feedback.setVisible(hasFeedbackMessage());
 		breadcrumbs.setVisible(breadcrumbs.getNumberOfCrumbs() > 0);
 	}
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
@@ -8,8 +8,7 @@
 <body>
 	<wicket:extend>
 		<form wicket:id="configurationForm">
-			<p class="shorttext">
-				<span class="reqStar">*</span>
+			<p class="shorttext form-required">
 				<label for="packageName">
 					<wicket:message key="form.label.package.name"></wicket:message>
 				</label>
@@ -18,8 +17,7 @@
 			<p class="instruction labelindnt">
 				<wicket:message key="form.instructions.open.date"></wicket:message>
 			</p>
-			<p class="shorttext">
-				<span class="reqStar">*</span>
+			<p class="shorttext form-required">
 				<label for="releaseOnDTF">
 					<wicket:message key="form.label.open.date"></wicket:message>
 				</label>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
@@ -88,7 +88,7 @@
 				<p style="clear:both;"/>
 			</div>
 			<div class="act">
-				<input type="submit" wicket:message="value:page.submit" class="active" />
+				<input wicket:id="save" type="submit" wicket:message="value:page.submit" class="active" />
 				<input wicket:id="cancel" type="submit" wicket:message="value:page.cancel" />
 			</div>
 		</form>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
@@ -287,35 +287,32 @@ public class PackageConfigurationPage extends ConsoleBasePage
 				}
 
 				// Only continue to update/save if there are no validation errors
-				if (!feedback.anyErrorMessage())
+				if (!feedback.anyErrorMessage() && gradebookSetup.isGradebookDefined())
 				{
-					if (gradebookSetup.isGradebookDefined())
+					String context = getContext();
+					List<AssessmentSetup> assessments = gradebookSetup.getAssessments();
+					for (AssessmentSetup assessmentSetup : assessments)
 					{
-						List<AssessmentSetup> assessments = gradebookSetup.getAssessments();
-						for (AssessmentSetup assessmentSetup : assessments)
+						boolean on = assessmentSetup.isSynchronizeSCOWithGradebook();
+						String assessmentExternalId = getAssessmentExternalId(gradebookSetup, assessmentSetup);
+						boolean has = gradebookExternalAssessmentService.isExternalAssignmentDefined(context, assessmentExternalId);
+						String fixedTitle = getItemTitle(assessmentSetup, context);
+						if (has && on)
 						{
-							boolean on = assessmentSetup.isSynchronizeSCOWithGradebook();
-							String assessmentExternalId = getAssessmentExternalId(gradebookSetup, assessmentSetup);
-							String context = getContext();
-							boolean has = gradebookExternalAssessmentService.isExternalAssignmentDefined(context, assessmentExternalId);
-							String fixedTitle = getItemTitle(assessmentSetup, context);
-							if (has && on)
-							{
-								gradebookExternalAssessmentService.updateExternalAssessment(context, assessmentExternalId, null, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn());
-							}
-							else if (!has && on)
-							{
-								gradebookExternalAssessmentService.addExternalAssessment(context, assessmentExternalId, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn(), "SCORM player", null);
-							}
-							else if (has && !on)
-							{
-								gradebookExternalAssessmentService.removeExternalAssessment(context, assessmentExternalId);
-							}
+							gradebookExternalAssessmentService.updateExternalAssessment(context, assessmentExternalId, null, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn());
 						}
-
-						contentService.updateContentPackage(contentPackage);
-						setResponsePage(pageSubmit);
+						else if (!has && on)
+						{
+							gradebookExternalAssessmentService.addExternalAssessment(context, assessmentExternalId, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn(), "SCORM player", null);
+						}
+						else if (has && !on)
+						{
+							gradebookExternalAssessmentService.removeExternalAssessment(context, assessmentExternalId);
+						}
 					}
+
+					contentService.updateContentPackage(contentPackage);
+					setResponsePage(pageSubmit);
 				}
 			}
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
@@ -24,9 +24,13 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.adl.validator.contentpackage.LaunchData;
+import org.apache.wicket.Component;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxCallListener;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
+import org.apache.wicket.extensions.ajax.markup.html.IndicatingAjaxButton;
 import org.apache.wicket.extensions.yui.calendar.DateTimeField;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -182,6 +186,7 @@ public class PackageConfigurationPage extends ConsoleBasePage
 	{
 		super(params);
 		long contentPackageId = params.get("contentPackageId").toLong();
+		this.unlimitedMessage = getLocalizer().getString("unlimited", this);
 
 		final ContentPackage contentPackage = contentService.getContentPackage(contentPackageId);
 		final GradebookSetup gradebookSetup = getAssessmentSetup(contentPackage);
@@ -203,64 +208,14 @@ public class PackageConfigurationPage extends ConsoleBasePage
 			pageCancel = PackageListPage.class;
 		}
 
-		Form form = new Form("configurationForm")
-		{
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			protected void onSubmit()
-			{
-				if (gradebookSetup.isGradebookDefined())
-				{
-					List<AssessmentSetup> assessments = gradebookSetup.getAssessments();
-					for (AssessmentSetup assessmentSetup : assessments)
-					{
-						boolean on = assessmentSetup.isSynchronizeSCOWithGradebook();
-						String assessmentExternalId = getAssessmentExternalId(gradebookSetup, assessmentSetup);
-						String context = getContext();
-						boolean has = gradebookExternalAssessmentService.isExternalAssignmentDefined(context, assessmentExternalId);
-						String fixedTitle = getItemTitle(assessmentSetup, context);
-						if (has && on)
-						{
-							gradebookExternalAssessmentService.updateExternalAssessment(context, assessmentExternalId, null, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn());
-						}
-						else if (!has && on)
-						{
-							gradebookExternalAssessmentService.addExternalAssessment(context, assessmentExternalId, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn(), "SCORM player", null);
-						}
-						else if (has && !on)
-						{
-							gradebookExternalAssessmentService.removeExternalAssessment(context, assessmentExternalId);
-						}
-					}
-				}
-
-				contentService.updateContentPackage(contentPackage);
-				setResponsePage(pageSubmit);
-			}
-
-			protected String getItemTitle(AssessmentSetup assessmentSetup, String context)
-			{
-				String fixedTitle = assessmentSetup.getItemTitle();
-				int count = 1;
-				while (gradebookExternalAssessmentService.isAssignmentDefined(context, fixedTitle))
-				{
-					fixedTitle = assessmentSetup.getItemTitle() + " (" + count++ + ")";
-				}
-
-				return fixedTitle;
-			}
-		};
-
 		List<Integer> tryList = new LinkedList<>();
-
 		tryList.add(-1);
 		for (int i = 1; i <= 10; i++)
 		{
 			tryList.add(i);
 		}
 
-		this.unlimitedMessage = getLocalizer().getString("unlimited", this);
+		Form form = new Form("configurationForm");
 
 		TextField nameField = new TextField("packageName", new PropertyModel(contentPackage, "title"));
 		nameField.setRequired(true);
@@ -313,7 +268,82 @@ public class PackageConfigurationPage extends ConsoleBasePage
 		});
 		scos.setVisible(gradebookSetup.isGradebookDefined() && !gradebookSetup.getAssessments().isEmpty());
 
-		form.add(new CancelButton("cancel", pageCancel));
+		final CancelButton btnCancel = new CancelButton("cancel", pageCancel);
+		btnCancel.setOutputMarkupId(true);
+		form.add(btnCancel);
+
+		final IndicatingAjaxButton btnSave = new IndicatingAjaxButton("save", form)
+		{
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			protected void onSubmit( AjaxRequestTarget target )
+			{
+				// Verify due date is after open date
+				if (contentPackage.getDueOn() != null && contentPackage.getReleaseOn() != null && contentPackage.getDueOn().before(contentPackage.getReleaseOn()))
+				{
+					error(getLocalizer().getString("form.error.dueDateBeforeOpenDate", this));
+					onError(target);
+				}
+
+				// Only continue to update/save if there are no validation errors
+				if (!feedback.anyErrorMessage())
+				{
+					if (gradebookSetup.isGradebookDefined())
+					{
+						List<AssessmentSetup> assessments = gradebookSetup.getAssessments();
+						for (AssessmentSetup assessmentSetup : assessments)
+						{
+							boolean on = assessmentSetup.isSynchronizeSCOWithGradebook();
+							String assessmentExternalId = getAssessmentExternalId(gradebookSetup, assessmentSetup);
+							String context = getContext();
+							boolean has = gradebookExternalAssessmentService.isExternalAssignmentDefined(context, assessmentExternalId);
+							String fixedTitle = getItemTitle(assessmentSetup, context);
+							if (has && on)
+							{
+								gradebookExternalAssessmentService.updateExternalAssessment(context, assessmentExternalId, null, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn());
+							}
+							else if (!has && on)
+							{
+								gradebookExternalAssessmentService.addExternalAssessment(context, assessmentExternalId, null, fixedTitle, assessmentSetup.numberOffPoints, gradebookSetup.getContentPackage().getDueOn(), "SCORM player", null);
+							}
+							else if (has && !on)
+							{
+								gradebookExternalAssessmentService.removeExternalAssessment(context, assessmentExternalId);
+							}
+						}
+
+						contentService.updateContentPackage(contentPackage);
+						setResponsePage(pageSubmit);
+					}
+				}
+			}
+
+			@Override
+			protected void onError(AjaxRequestTarget target)
+			{
+				target.add(feedback);
+				target.add(this);
+				target.add(btnCancel);
+			}
+
+			@Override
+			protected void updateAjaxAttributes(AjaxRequestAttributes attributes)
+			{
+				super.updateAjaxAttributes(attributes);
+				AjaxCallListener listener = new AjaxCallListener()
+				{
+					@Override
+					public CharSequence getAfterHandler(Component component)
+					{
+						return "this.disabled = true; document.getElementsByName( \"cancel\" )[0].disabled = true;";
+					}
+				};
+				attributes.getAjaxCallListeners().add(listener);
+			}
+		};
+		btnSave.setOutputMarkupId(true);
+		form.add(btnSave);
 		add(form);
 	}
 
@@ -352,5 +382,17 @@ public class PackageConfigurationPage extends ConsoleBasePage
 	{
 		String assessmentExternalId = "" + gradebook.getContentPackageId() + ":" + assessment.getLaunchData().getItemIdentifier();
 		return assessmentExternalId;
+	}
+
+	private String getItemTitle(AssessmentSetup assessmentSetup, String context)
+	{
+		String fixedTitle = assessmentSetup.getItemTitle();
+		int count = 1;
+		while (gradebookExternalAssessmentService.isAssignmentDefined(context, fixedTitle))
+		{
+			fixedTitle = assessmentSetup.getItemTitle() + " (" + count++ + ")";
+		}
+
+		return fixedTitle;
 	}
 }

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
@@ -11,6 +11,9 @@ form.label.open.date                  = Open Date:
 form.label.package.name               = Name:
 form.label.synchronyse.with.gradebook = Synchronize score to Gradebook
 form.label.hide.toc                   = Hide Table of Contents
+
+form.error.dueDateBeforeOpenDate      = The Due Date cannot be set before the Open Date. Please select a different Due Date.
+
 page.title = Configure Learning Content Package
 
 unlimited = Unlimited

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/res/scorm_console.css
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/res/scorm_console.css
@@ -179,3 +179,10 @@
     height:2px;
     margin:0 1px;
 }
+
+.form-required label::before {
+    content: "*";
+    color: #c77070;
+    position: relative;
+    top: 3px;
+}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-157

Currently you can set the due date prior to the open date. In effect, students will never be able to access this module until the instructor realizes their mistake and changes the due date to be after the open date.

Introduce some form validation to block the user from entering this scenario, and provide appropriate feedback messaging to inform them of the problem and how to rectify it.