### PR TITLE
SCO-158: improve messaging when deleting a module

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageRemovePage.properties
@@ -1,5 +1,5 @@
 page.title = Remove Module
 page.submit = Remove
 page.cancel = Cancel
-verify.remove = Are you sure you want to remove the following learning module? All grades associated with this module will be deleted.
+verify.remove = Are you sure you want to remove the following learning module? Any data associated with this module (including grades, attempts, and results) will be deleted.
 exception.remove = Content package has been deleted, but some underlying resources may not have been fully cleaned up.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-158

Currently when a user attempts to delete a module, they are presented with the following message:

> Are you sure you want to remove the following learning module? All grades associated with this module will be deleted

We've had reports that this message is confusing, especially in scenarios where the module is not linked to the Gradebook. This PR proposes changing this message to the following:

> Are you sure you want to remove the following learning module? Any data associated with this module (including grades, attempts, and results) will be deleted.