### PR TITLE
SCO-162: "Previous learner" & "Next learner" links navigate users in an arbitrary order

### DIFF
--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
@@ -21,7 +21,7 @@ import java.util.Properties;
 import lombok.Getter;
 import lombok.Setter;
 
-public class Learner implements Serializable
+public class Learner implements Serializable, Comparable<Learner>
 {
 	private static final long serialVersionUID = 1L;
 
@@ -41,5 +41,11 @@ public class Learner implements Serializable
 		this.id = id;
 		this.displayName = displayName;
 		this.displayId = displayId;
+	}
+
+	@Override
+	public int compareTo(Learner learner)
+	{
+		return this.sortName.compareTo(learner.sortName);
 	}
 }

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/Learner.java
@@ -46,6 +46,6 @@ public class Learner implements Serializable, Comparable<Learner>
 	@Override
 	public int compareTo(Learner learner)
 	{
-		return this.sortName.compareTo(learner.sortName);
+		return sortName.compareTo(learner.sortName);
 	}
 }

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package org.sakaiproject.scorm.service.impl;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -436,6 +437,7 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 			// We just have the above ids
 			String context = lms().currentContext();
 			List<Learner> learners = learnerDao().find(context);
+			Collections.sort(learners);
 
 			for (int i = 0; i < learners.size(); i++)
 			{


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-162

1. Visit results for a SCORM module
2. Click on a user from the table
3. Use the "next learner" and/or "previous learner" links
* Notice it does not follow the same order from the table in the previous interface, and appears random

Fix this so that it navigates students in the same order as shown in the table.