### PR TITLE
SCO-163: Prevent erroneous negative score in gradebook when module does not record value for 'cmi.score.scaled'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <name>SCORM Player</name>
+    <groupId>org.sakaiproject.scorm</groupId>
     <artifactId>scorm-base</artifactId>
     <version>20-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -153,4 +154,12 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <site>
+            <id>sakai-site</id>
+            <name>Sakai Release Site</name>
+            <url>scpexe://source.sakaiproject.org/var/www/html/release/scorm/${project.version}</url>
+        </site>
+    </distributionManagement>
 </project>

--- a/scorm-api/pom.xml
+++ b/scorm-api/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/scorm-api/src/java/org/adl/datamodels/ieee/SCORM_2004_DM.java
+++ b/scorm-api/src/java/org/adl/datamodels/ieee/SCORM_2004_DM.java
@@ -51,6 +51,8 @@ import org.adl.datamodels.datatypes.URIValidator;
 import org.adl.datamodels.datatypes.VocabularyValidator;
 import org.adl.util.MessageCollection;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
+
 /**
  * <strong>Filename:</strong> SCORM_2004_DM.java<br><br>
  *
@@ -1092,7 +1094,7 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 
 		int err = DMErrorCodes.NO_ERROR;
 
-		req = new DMRequest("cmi.total_time");
+		req = new DMRequest(CMI_TOTAL_TIME);
 		req.getNextToken();
 
 		dmInfo = new DMProcessingInfo();
@@ -1100,7 +1102,7 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 
 		String totalTime = dmInfo.mValue;
 
-		req = new DMRequest("cmi.session_time", true, false);
+		req = new DMRequest(CMI_SESSION_TIME, true, false);
 		req.getNextToken();
 
 		dmInfo = new DMProcessingInfo();
@@ -1108,13 +1110,13 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 		if (err == DMErrorCodes.NO_ERROR) {
 			String sessionTime = dmInfo.mValue;
 			String addedTime = DMTimeUtility.add(totalTime, sessionTime);
-			req = new DMRequest("cmi.total_time", addedTime, true);
+			req = new DMRequest(CMI_TOTAL_TIME, addedTime, true);
 			req.getNextToken();
 			err = setValue(req, validatorFactory);
 		}
 
 		// Update completion status
-		req = new DMRequest("cmi.progress_measure");
+		req = new DMRequest(CMI_PROGRESS_MEASURE);
 		req.getNextToken();
 
 		dmInfo = new DMProcessingInfo();
@@ -1122,7 +1124,7 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 
 		String progress = dmInfo.mValue;
 
-		req = new DMRequest("cmi.completion_threshold");
+		req = new DMRequest(CMI_COMPLETION_THRESHOLD);
 		req.getNextToken();
 
 		dmInfo = new DMProcessingInfo();
@@ -1132,12 +1134,12 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 
 		if (progress != null && threshold != null && (!progress.isEmpty()) && (!threshold.isEmpty())) {
 			if (Double.parseDouble(progress) >= Double.parseDouble(threshold)) {
-				req = new DMRequest("cmi.completion_status", "completed", true);
+				req = new DMRequest(CMI_COMPLETION_STATUS, "completed", true);
 				req.getNextToken();
 
 				err = setValue(req, validatorFactory);
 			} else if (Double.parseDouble(progress) < Double.parseDouble(threshold)) {
-				req = new DMRequest("cmi.completion_status", "incomplete", true);
+				req = new DMRequest(CMI_COMPLETION_STATUS, "incomplete", true);
 				req.getNextToken();
 
 				err = setValue(req, validatorFactory);
@@ -1153,7 +1155,7 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 
 		progress = dmInfo.mValue;
 
-		req = new DMRequest("cmi.scaled_passing_score");
+		req = new DMRequest(CMI_SCALED_PASSING_SCORE);
 		req.getNextToken();
 
 		dmInfo = new DMProcessingInfo();
@@ -1164,19 +1166,19 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 		if (threshold != null && !threshold.isEmpty()) {
 			if (progress != null && !progress.isEmpty()) {
 				if (Double.parseDouble(progress) >= Double.parseDouble(threshold)) {
-					req = new DMRequest("cmi.success_status", "passed", true);
+					req = new DMRequest(CMI_SUCCESS_STATUS, "passed", true);
 					req.getNextToken();
 
 					err = setValue(req, validatorFactory);
 				} else {
-					req = new DMRequest("cmi.success_status", "failed", true);
+					req = new DMRequest(CMI_SUCCESS_STATUS, "failed", true);
 					req.getNextToken();
 
 					err = setValue(req, validatorFactory);
 				}
 			} else {
 				// Reset success_status to unknown
-				req = new DMRequest("cmi.success_status", "unknown", true);
+				req = new DMRequest(CMI_SUCCESS_STATUS, "unknown", true);
 				req.getNextToken();
 
 				err = setValue(req, validatorFactory);
@@ -1184,7 +1186,7 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 		}
 
 		// Set the entry flag based on the exit value
-		req = new DMRequest("cmi.exit", true, false);
+		req = new DMRequest(CMI_EXIT, true, false);
 		req.getNextToken();
 
 		dmInfo = new DMProcessingInfo();
@@ -1194,7 +1196,7 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 		if (dmInfo.mValue.equals("suspend") || dmInfo.mValue.equals("logout")) {
 			// The next time this SCO is experienced, the current
 			// Learner Session will be "resumed"
-			req = new DMRequest("cmi.entry", "resume", true);
+			req = new DMRequest(CMI_ENTRY, "resume", true);
 			req.getNextToken();
 
 			err = setValue(req, validatorFactory);
@@ -1206,14 +1208,14 @@ public class SCORM_2004_DM extends DataModel implements Serializable {
 			SCORM_2004_DMElement element = new SCORM_2004_DMElement(desc, null, this);
 			mElements.put(desc.mBinding, element);
 		} else {
-			req = new DMRequest("cmi.entry", "", true);
+			req = new DMRequest(CMI_ENTRY, "", true);
 			req.getNextToken();
 
 			err = setValue(req, validatorFactory);
 		}
 
 		// This Learner Session is over, clear cmi.exit
-		req = new DMRequest("cmi.exit", "", true);
+		req = new DMRequest(CMI_EXIT, "", true);
 		req.getNextToken();
 
 		err = setValue(req, validatorFactory);

--- a/scorm-api/src/java/org/sakaiproject/scorm/api/ScormConstants.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/api/ScormConstants.java
@@ -17,9 +17,6 @@ package org.sakaiproject.scorm.api;
 
 public class ScormConstants
 {
-	/** This string starts the references to resources in this service. */
-	public static final String REFERENCE_ROOT = "/scorm";
-
 	public static String IS_CONTENT_PACKAGE_PROPERTY = "scorm:is_content_package";
 
 	public static String CONTENT_PACKAGE_TITLE_PROPERTY = "CONTENT_PACKAGE_TITLE";
@@ -44,13 +41,57 @@ public class ScormConstants
 
 	public final static String CMI_OBJECTIVES_ROOT = "cmi.objectives.";
 
+    public final static String CMI_OBJECTIVES_COUNT = CMI_OBJECTIVES_ROOT + "_count";
+
+    public final static String CMI_INTERACTIONS_ROOT = "cmi.interactions.";
+
+    public final static String CMI_INTERACTIONS_COUNT = CMI_INTERACTIONS_ROOT + "_count";
+
 	public final static String CMI_COMPLETION_STATUS = "cmi.completion_status";
+
+    public final static String CMI_COMPLETION_THRESHOLD = "cmi.completion_threshold";
 
 	public final static String CMI_SUCCESS_STATUS = "cmi.success_status";
 
+    public final static String CMI_SUSPEND_DATA = "cmi.suspend_data";
+
 	public final static String CMI_ENTRY = "cmi.entry";
 
+    public final static String CMI_CREDIT = "cmi.credit";
+
+    public final static String CMI_EXIT = "cmi.exit";
+
+    public final static String CMI_LAUNCH_DATA = "cmi.launch_data";
+
+    public final static String CMI_LEARNER_ID = "cmi.learner_id";
+
+    public final static String CMI_LEARNER_NAME = "cmi.learner_name";
+
+    public final static String CMI_LOCATION = "cmi.location";
+
+    public final static String CMI_MAX_TIME_ALLOWED = "cmi.max_time_allowed";
+
+    public final static String CMI_TIME_LIMIT_ACTION = "cmi.time_limit_action";
+
+    public final static String CMI_TOTAL_TIME = "cmi.total_time";
+
+    public final static String CMI_TIMESTAMP = "cmi.timestamp";
+
+    public final static String CMI_COMMENTS_FROM_LEARNER = "cmi.comments_from_learner";
+
+    public final static String CMI_MODE = "cmi.mode";
+
+    public final static String CMI_PROGRESS_MEASURE = "cmi.progress_measure";
+
+    public final static String CMI_SCALED_PASSING_SCORE = "cmi.scaled_passing_score";
+
 	public final static String CMI_SCORE_SCALED = "cmi.score.scaled";
+
+    public final static String CMI_SCORE_RAW = "cmi.score.raw";
+
+    public final static String CMI_SCORE_MIN = "cmi.score.min";
+
+    public final static String CMI_SCORE_MAX = "cmi.score.max";
 
 	public final static String CMI_SESSION_TIME = "cmi.session_time";
 

--- a/scorm-impl/adl/pom.xml
+++ b/scorm-impl/adl/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/scorm-impl/adl/src/test/org/adl/datamodels/ieee/SCORM_2004_DMTest.java
+++ b/scorm-impl/adl/src/test/org/adl/datamodels/ieee/SCORM_2004_DMTest.java
@@ -8,6 +8,8 @@ import org.adl.datamodels.DMProcessingInfo;
 import org.adl.datamodels.DMRequest;
 import org.adl.datamodels.DataModel;
 
+import static org.sakaiproject.scorm.api.ScormConstants.CMI_COMMENTS_FROM_LEARNER;
+
 public class SCORM_2004_DMTest extends TestCase {
 	DataModel dm;
 	IValidatorFactory validatorFactory;
@@ -33,30 +35,30 @@ public class SCORM_2004_DMTest extends TestCase {
 		assertEquals("cmi", dm.getDMBindingString());
 		assertEquals("1.0", getElementValue("cmi._version"));
 		{
-			DMRequest request = new DMRequest("cmi.comments_from_learner.0.comment", "{lang=en}Characterstring in the English language");
+			DMRequest request = new DMRequest(CMI_COMMENTS_FROM_LEARNER + ".0.comment", "{lang=en}Characterstring in the English language");
 			request.getNextToken();
 			assertEquals(DMErrorCodes.NO_ERROR, dm.setValue(request, validatorFactory));
 		}
 		assertEquals("comments_from_learner", dm.getDMElement("comments_from_learner").getDMElementBindingString());
 		{
-			assertEquals("Characterstring in the English language", getElementValue("cmi.comments_from_learner.0.comment"));
-			assertEquals("1", getElementValue("cmi.comments_from_learner._count"));
-			assertTrue(getElementValue("cmi.comments_from_learner._children").contains("comment"));
-			assertTrue(getElementValue("cmi.comments_from_learner._children").contains("location"));
-			assertTrue(getElementValue("cmi.comments_from_learner._children").contains("timestamp"));
+			assertEquals("Characterstring in the English language", getElementValue(CMI_COMMENTS_FROM_LEARNER + ".0.comment"));
+			assertEquals("1", getElementValue(CMI_COMMENTS_FROM_LEARNER + "._count"));
+			assertTrue(getElementValue(CMI_COMMENTS_FROM_LEARNER + "._children").contains("comment"));
+			assertTrue(getElementValue(CMI_COMMENTS_FROM_LEARNER + "._children").contains("location"));
+			assertTrue(getElementValue(CMI_COMMENTS_FROM_LEARNER + "._children").contains("timestamp"));
 			System.out.println(dm.toString());
 		}
 		{
-			DMRequest request = new DMRequest("cmi.comments_from_learner.2.comment");
+			DMRequest request = new DMRequest(CMI_COMMENTS_FROM_LEARNER + ".2.comment");
 			request.getNextToken();
 			assertEquals(DMErrorCodes.OUT_OF_RANGE, dm.getValue(request, new DMProcessingInfo()));
 		}
 		{
-			DMRequest request = new DMRequest("cmi.comments_from_learner.1.comment", "{lang=de}Characterstring in the German language");
+			DMRequest request = new DMRequest(CMI_COMMENTS_FROM_LEARNER + ".1.comment", "{lang=de}Characterstring in the German language");
 			request.getNextToken();
 			assertEquals(DMErrorCodes.NO_ERROR, dm.setValue(request, validatorFactory));
-			assertEquals("2", getElementValue("cmi.comments_from_learner._count"));
-			assertEquals("{lang=de}Characterstring in the German language", getElementValue("cmi.comments_from_learner.1.comment"));
+			assertEquals("2", getElementValue(CMI_COMMENTS_FROM_LEARNER+ "._count"));
+			assertEquals("{lang=de}Characterstring in the German language", getElementValue(CMI_COMMENTS_FROM_LEARNER + ".1.comment"));
 		}
 	}
 }

--- a/scorm-impl/client/pom.xml
+++ b/scorm-impl/client/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/scorm-impl/content/pom.xml
+++ b/scorm-impl/content/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ScormCHH.java
+++ b/scorm-impl/content/src/java/org/sakaiproject/scorm/content/impl/ScormCHH.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.content.api.ContentCollectionEdit;
 import org.sakaiproject.content.api.ContentEntity;
 import org.sakaiproject.content.api.ContentHostingHandlerResolver;
@@ -30,7 +31,6 @@ import org.sakaiproject.content.api.ContentResource;
 import org.sakaiproject.entity.api.Entity;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
-import org.sakaiproject.scorm.api.ScormConstants;
 import org.sakaiproject.scorm.service.api.ScormContentService;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -237,11 +237,11 @@ public class ScormCHH extends FastZipCHH
 			virtualCollection.setContentHandler(this);
 			ce.setVirtualContentEntity(virtualCollection);
 
-			if (realProperties.getProperty(ScormConstants.CONTENT_PACKAGE_TITLE_PROPERTY) != null)
+			if (realProperties.getProperty(CONTENT_PACKAGE_TITLE_PROPERTY) != null)
 			{
 				ResourcePropertiesEdit virtualProps = virtualCollection.getPropertiesEdit();
-				virtualProps.addProperty(ScormConstants.CONTENT_PACKAGE_TITLE_PROPERTY, realProperties.getProperty(ScormConstants.CONTENT_PACKAGE_TITLE_PROPERTY));
-				virtualProps.addProperty(ScormConstants.IS_CONTENT_PACKAGE_PROPERTY, "true");
+				virtualProps.addProperty(CONTENT_PACKAGE_TITLE_PROPERTY, realProperties.getProperty(CONTENT_PACKAGE_TITLE_PROPERTY));
+				virtualProps.addProperty(IS_CONTENT_PACKAGE_PROPERTY, "true");
 			}
 
 			virtualEntity = virtualCollection;

--- a/scorm-impl/model/pom.xml
+++ b/scorm-impl/model/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/scorm-impl/model/src/test/org/sakaiproject/scorm/dao/hibernate/DataManagerDaoImplTest.java
+++ b/scorm-impl/model/src/test/org/sakaiproject/scorm/dao/hibernate/DataManagerDaoImplTest.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.sakaiproject.scorm.api.ScormConstants.CMI_INTERACTIONS_ROOT;
 import org.sakaiproject.scorm.dao.api.DataManagerDao;
 
 public class DataManagerDaoImplTest extends AbstractServiceTest
@@ -48,11 +49,11 @@ public class DataManagerDaoImplTest extends AbstractServiceTest
 		dataManager.addDM(DMFactory.DM_SSP, validatorFactory);
 		dataManager.setScoId("sco01");
 		dataManagerDao.save(dataManager);
-		dataManager.setValue(new DMRequest("cmi.interactions.0.id", "1"), validatorFactory);
+		dataManager.setValue(new DMRequest(CMI_INTERACTIONS_ROOT + "0.id", "1"), validatorFactory);
 
 		dataManagerDao.update(dataManager);
 
-		Assert.assertEquals(0, dataManager.getValue(new DMRequest("cmi.interactions.0.id"), new DMProcessingInfo()));
-		Assert.assertEquals(DMErrorCodes.OUT_OF_RANGE, dataManager.getValue(new DMRequest("cmi.interactions.1.id"), new DMProcessingInfo()));
+		Assert.assertEquals(0, dataManager.getValue(new DMRequest(CMI_INTERACTIONS_ROOT + "0.id"), new DMProcessingInfo()));
+		Assert.assertEquals(DMErrorCodes.OUT_OF_RANGE, dataManager.getValue(new DMRequest(CMI_INTERACTIONS_ROOT + "1.id"), new DMProcessingInfo()));
 	}
 }

--- a/scorm-impl/pack/pom.xml
+++ b/scorm-impl/pack/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/scorm-impl/service/pom.xml
+++ b/scorm-impl/service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/scorm-impl/service/src/bundle/messages.properties
+++ b/scorm-impl/service/src/bundle/messages.properties
@@ -6,3 +6,6 @@ htmlHeader=<html><head><link rel="stylesheet" href="{0}" type="text/css"</head><
 htmlIframe=<iframe height="100%" width="100%" frameborder="0" src="{0}"></iframe>
 htmlH2=<div class="sak-banner-warn" style="margin-left: auto; margin-right: auto; margin-top: 20px;">{0}</div>
 htmlFooter=</body></html>
+
+# Gradebook comment indicating module did not record any grading data
+moduleNoScoreRecorded=[This SCORM module did not record any grading data]

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/ScormEntityProviderImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/ScormEntityProviderImpl.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang.StringUtils;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.entitybroker.EntityReference;
@@ -51,7 +52,6 @@ import org.sakaiproject.entitybroker.entityprovider.extension.Formats;
 import org.sakaiproject.entitybroker.entityprovider.extension.RequestGetter;
 import org.sakaiproject.entitybroker.entityprovider.search.Search;
 import org.sakaiproject.exception.IdUnusedException;
-import org.sakaiproject.scorm.api.ScormConstants;
 import org.sakaiproject.scorm.model.api.ContentPackage;
 import org.sakaiproject.scorm.service.api.ScormContentService;
 import org.sakaiproject.site.api.Site;
@@ -175,10 +175,10 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 					if( site != null )
 					{
 						// Check to make sure the current user has the 'scorm.configure' permission for the site
-						if( !securityService.unlock( userID, ScormConstants.PERM_CONFIG, siteService.siteReference( siteID ) ) )
+						if( !securityService.unlock( userID, PERM_CONFIG, siteService.siteReference( siteID ) ) )
 						{
 							// Log the message that this user doesn't have the permision for the site, return an empty list
-							log.error( "User ({}) does not have permission ({}) for site: {}", userID, ScormConstants.PERM_CONFIG, siteID );
+							log.error( "User ({}) does not have permission ({}) for site: {}", userID, PERM_CONFIG, siteID );
 							return entityRefs;
 						}
 
@@ -391,7 +391,7 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 		log.debug( "isCurrentUserLaunchAuth()" );
 
 		String userID = userDirectoryService.getCurrentUser().getId();
-		return securityService.unlock( userID, ScormConstants.PERM_LAUNCH, siteService.siteReference( siteID ) );
+		return securityService.unlock( userID, PERM_LAUNCH, siteService.siteReference( siteID ) );
 	}
 
 	/**

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
@@ -45,8 +45,8 @@ import org.adl.validator.contentpackage.ILaunchData;
 
 import org.apache.commons.lang.StringUtils;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.scorm.adl.ADLConsultant;
-import org.sakaiproject.scorm.api.ScormConstants;
 import org.sakaiproject.scorm.dao.LearnerDao;
 import org.sakaiproject.scorm.dao.api.AttemptDao;
 import org.sakaiproject.scorm.dao.api.DataManagerDao;
@@ -115,10 +115,10 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 
 			if (sessionBean.isSuspended())
 			{
-				setValue("cmi.exit", "suspend", sessionBean, sessionBean.getDisplayingSco());
+				setValue(CMI_EXIT, "suspend", sessionBean, sessionBean.getDisplayingSco());
 			}
 			else if (sessionBean.isEnded()) {
-				setValue("cmi.exit", "normal", sessionBean, sessionBean.getDisplayingSco());
+				setValue(CMI_EXIT, "normal", sessionBean, sessionBean.getDisplayingSco());
 			}
 
 			// Call terminate on the data manager to ensure that we're in the appropriate state
@@ -516,12 +516,12 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 					mObjStatus = (ADLObjStatus) mStatusVector.get(i);
 
 					// Set the objectives id
-					obj = "cmi.objectives." + i + ".id";
+					obj = CMI_OBJECTIVES_ROOT + i + ".id";
 
 					err = DMInterface.processSetValue(obj, mObjStatus.mObjID, true, dm, validatorFactory);
 
 					// Set the objectives success status
-					obj = "cmi.objectives." + i + ".success_status";
+					obj = CMI_OBJECTIVES_ROOT + i + ".success_status";
 
 					if (mObjStatus.mStatus.equalsIgnoreCase("satisfied"))
 					{
@@ -533,7 +533,7 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 					}
 
 					// Set the objectives scaled score
-					obj = "cmi.objectives." + i + ".score.scaled";
+					obj = CMI_OBJECTIVES_ROOT + i + ".score.scaled";
 
 					if (mObjStatus.mHasMeasure)
 					{
@@ -553,14 +553,14 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 
 					// get the count of current objectives
 					DMProcessingInfo pi = new DMProcessingInfo();
-					int result = DMInterface.processGetValue("cmi.objectives._count", true, dm, pi);
+					int result = DMInterface.processGetValue(CMI_OBJECTIVES_COUNT, true, dm, pi);
 					int objCount = (Integer.valueOf(pi.mValue));
 
 					// Find the current index for this objective
 					for (int j = 0; j < objCount; j++)
 					{
 						pi = new DMProcessingInfo();
-						obj = "cmi.objectives." + j + ".id";
+						obj = CMI_OBJECTIVES_ROOT + j + ".id";
 						result = DMInterface.processGetValue(obj, true, dm, pi);
 						if (pi.mValue.equals(mObjStatus.mObjID))
 						{
@@ -572,7 +572,7 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 					if (idx != -1)
 					{
 						// Set the objectives success status
-						obj = "cmi.objectives." + idx + ".success_status";
+						obj = CMI_OBJECTIVES_ROOT + idx + ".success_status";
 
 						if (mObjStatus.mStatus.equalsIgnoreCase("satisfied"))
 						{
@@ -584,7 +584,7 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 						}
 
 						// Set the objectives scaled score
-						obj = "cmi.objectives." + idx + ".score.scaled";
+						obj = CMI_OBJECTIVES_ROOT + idx + ".score.scaled";
 
 						if (mObjStatus.mHasMeasure)
 						{
@@ -670,10 +670,10 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 			String completionThreshold = "";
 
 			// User preferences
-			String audLev = ScormConstants.DEFAULT_USER_AUDIO_LEVEL;
-			String audCap = ScormConstants.DEFAULT_USER_AUDIO_CAPTIONING;
-			String delSpd = ScormConstants.DEFAULT_USER_DELIVERY_SPEED;
-			String lang = ScormConstants.DEFAULT_USER_LANGUAGE;
+			String audLev = DEFAULT_USER_AUDIO_LEVEL;
+			String audCap = DEFAULT_USER_AUDIO_CAPTIONING;
+			String delSpd = DEFAULT_USER_DELIVERY_SPEED;
+			String lang = DEFAULT_USER_LANGUAGE;
 
 			// Get the learner preference values from Sakai
 			Properties props = null;
@@ -684,21 +684,21 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 
 			if (props != null)
 			{
-				if (null != props.getProperty(ScormConstants.PREF_USER_AUDIO_LEVEL))
+				if (null != props.getProperty(PREF_USER_AUDIO_LEVEL))
 				{
-					audLev = props.getProperty(ScormConstants.PREF_USER_AUDIO_LEVEL);
+					audLev = props.getProperty(PREF_USER_AUDIO_LEVEL);
 				}
-				if (null != props.getProperty(ScormConstants.PREF_USER_AUDIO_CAPTIONING))
+				if (null != props.getProperty(PREF_USER_AUDIO_CAPTIONING))
 				{
-					audCap = props.getProperty(ScormConstants.PREF_USER_AUDIO_CAPTIONING);
+					audCap = props.getProperty(PREF_USER_AUDIO_CAPTIONING);
 				}
-				if (null != props.getProperty(ScormConstants.PREF_USER_DELIVERY_SPEED))
+				if (null != props.getProperty(PREF_USER_DELIVERY_SPEED))
 				{
-					delSpd = props.getProperty(ScormConstants.PREF_USER_DELIVERY_SPEED);
+					delSpd = props.getProperty(PREF_USER_DELIVERY_SPEED);
 				}
-				if (null != props.getProperty(ScormConstants.PREF_USER_LANGUAGE))
+				if (null != props.getProperty(PREF_USER_LANGUAGE))
 				{
-					lang = props.getProperty(ScormConstants.PREF_USER_LANGUAGE);
+					lang = props.getProperty(PREF_USER_LANGUAGE);
 				}
 			}
 
@@ -713,54 +713,54 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 			if (null != learner)
 			{
 				// Initialize the learner id
-				element = "cmi.learner_id";
+				element = CMI_LEARNER_ID;
 				DMInterface.processSetValue(element, learner.getId(), true, ioSCOData, validatorFactory);
 
 				// Initialize the learner name
-				element = "cmi.learner_name";
+				element = CMI_LEARNER_NAME;
 				DMInterface.processSetValue(element, learner.getDisplayName(), true, ioSCOData, validatorFactory);
 			}
 
 			// Initialize the cmi.credit value
-			element = "cmi.credit";
+			element = CMI_CREDIT;
 			DMInterface.processSetValue(element, "credit", true, ioSCOData, validatorFactory);
 
 			// Initialize the mode
-			element = "cmi.mode";
+			element = CMI_MODE;
 			DMInterface.processSetValue(element, "normal", true, ioSCOData, validatorFactory);
 
 			// Initialize any launch data
 			if (dataFromLMS != null && !dataFromLMS.isEmpty())
 			{
-				element = "cmi.launch_data";
+				element = CMI_LAUNCH_DATA;
 				DMInterface.processSetValue(element, dataFromLMS, true, ioSCOData, validatorFactory);
 			}
 
 			// Initialize the scaled passing score
 			if (masteryScore != null && !masteryScore.isEmpty())
 			{
-				element = "cmi.scaled_passing_score";
+				element = CMI_SCALED_PASSING_SCORE;
 				DMInterface.processSetValue(element, masteryScore, true, ioSCOData, validatorFactory);
 			}
 
 			// Initialize the time limit action
 			if (timeLimitAction != null && !timeLimitAction.isEmpty())
 			{
-				element = "cmi.time_limit_action";
+				element = CMI_TIME_LIMIT_ACTION;
 				DMInterface.processSetValue(element, timeLimitAction, true, ioSCOData, validatorFactory);
 			}
 
 			// Initialize the completion_threshold
 			if (completionThreshold != null && !completionThreshold.isEmpty())
 			{
-				element = "cmi.completion_threshold";
+				element = CMI_COMPLETION_THRESHOLD;
 				DMInterface.processSetValue(element, completionThreshold, true, ioSCOData, validatorFactory);
 			}
 
 			// Initialize the max time allowed
 			if (maxTime != null && !maxTime.isEmpty())
 			{
-				element = "cmi.max_time_allowed";
+				element = CMI_MAX_TIME_ALLOWED;
 				DMInterface.processSetValue(element, maxTime, true, ioSCOData, validatorFactory);
 			}
 
@@ -819,7 +819,7 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 		status.activityId = activityId;
 
 		// Get the current completion_status
-		status.completionStatus = retrieveValue(ScormConstants.CMI_COMPLETION_STATUS, "unknown", dm);
+		status.completionStatus = retrieveValue(CMI_COMPLETION_STATUS, "unknown", dm);
 
 		if (status.completionStatus.equals("not attempted"))
 		{
@@ -827,16 +827,16 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 		}
 
 		// Get the current success_status
-		status.masteryStatus = retrieveValue(ScormConstants.CMI_SUCCESS_STATUS, "unknown", dm);
+		status.masteryStatus = retrieveValue(CMI_SUCCESS_STATUS, "unknown", dm);
 
 		// Get the current entry
-		status.SCOEntry = retrieveValueAsAdmin(ScormConstants.CMI_ENTRY, "unknown", dm);
+		status.SCOEntry = retrieveValueAsAdmin(CMI_ENTRY, "unknown", dm);
 
 		// Get the current scaled score
-		status.score = retrieveValueAsAdmin(ScormConstants.CMI_SCORE_SCALED, "", dm);
+		status.score = retrieveValueAsAdmin(CMI_SCORE_SCALED, "", dm);
 
 		// Get the current session time
-		status.sessionTime = retrieveValueAsAdmin(ScormConstants.CMI_SESSION_TIME, "unknown", dm);
+		status.sessionTime = retrieveValueAsAdmin(CMI_SESSION_TIME, "unknown", dm);
 		return status;
 	}
 
@@ -866,13 +866,13 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 		for (int i = 0; i < numObjs; i++)
 		{
 			// Get this objectives id
-			String objIdRequest = new StringBuilder(ScormConstants.CMI_OBJECTIVES_ROOT).append(i).append(".id").toString();
+			String objIdRequest = new StringBuilder(CMI_OBJECTIVES_ROOT).append(i).append(".id").toString();
 			String objID = retrieveValue(objIdRequest, "", dm);
 
 			foundPrimaryObj = cmiData.primaryObjectiveId != null && objID.equals(cmiData.primaryObjectiveId);
 
 			// Get this objectives mastery
-			String objMsRequest = new StringBuilder(ScormConstants.CMI_OBJECTIVES_ROOT).append(i).append(".success_status").toString();
+			String objMsRequest = new StringBuilder(CMI_OBJECTIVES_ROOT).append(i).append(".success_status").toString();
 			String objMS = retrieveValue(objMsRequest, "", dm);
 
 			// Report the success status
@@ -900,7 +900,7 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 			}
 
 			// Get this objectives measure
-			String objScoreRequest = new StringBuilder(ScormConstants.CMI_OBJECTIVES_ROOT).append(i).append(".score.scaled").toString();
+			String objScoreRequest = new StringBuilder(CMI_OBJECTIVES_ROOT).append(i).append(".score.scaled").toString();
 			String objScore = retrieveValue(objScoreRequest, "unknown", dm);
 
 			// Report the measure
@@ -977,7 +977,7 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 
 			// Get the activities objective list
 			// Map the DM to the TM
-			String size = retrieveValue("cmi.objectives._count", "none", dm);
+			String size = retrieveValue(CMI_OBJECTIVES_COUNT, "none", dm);
 			if (!size.equals("none"))
 			{
 				try
@@ -1194,16 +1194,16 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 		IDataManager dataManager = getDataManager(displayingSco);
 
 		// passed, failed, unknown
-		String mode = getValueAsString("cmi.mode", dataManager);
+		String mode = getValueAsString(CMI_MODE, dataManager);
 
 		// credit, no_credit
-		String credit = getValueAsString("cmi.credit", dataManager);
+		String credit = getValueAsString(CMI_CREDIT, dataManager);
 
 		// (completed, incomplete, not_attempted, unknown)
-		String completionStatus = getValueAsString("cmi.completion_status", dataManager);
+		String completionStatus = getValueAsString(CMI_COMPLETION_STATUS, dataManager);
 
 		// A real number with values that is accurate to seven significant decimal figures. The value shall be in the range of �1.0 to 1.0, inclusive.
-		double score = getRealValue("cmi.score.scaled", dataManager) * 100d;
+		double score = getRealValue(CMI_SCORE_SCALED, dataManager) * 100d;
 
 		if ("normal".equals(mode) && "completed".equals(completionStatus) && "credit".equals(credit))
 		{
@@ -1267,12 +1267,12 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 			{
 				// Before we change the cmi.exit, make sure the SCO didn't set it to log-out.
 				DMProcessingInfo pi = new DMProcessingInfo();
-				int check = DMInterface.processGetValue("cmi.exit", true, dataManager, pi);
+				int check = DMInterface.processGetValue(CMI_EXIT, true, dataManager, pi);
 
 				if (check != 0 || !pi.mValue.equals("log-out"))
 				{
 					// Process 'SET' on cmi.exit
-					DMInterface.processSetValue("cmi.exit", "suspend", true, dataManager, validatorFactory);
+					DMInterface.processSetValue(CMI_EXIT, "suspend", true, dataManager, validatorFactory);
 				}
 			}
 
@@ -1296,7 +1296,7 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 				// get value of "exit"
 				DMProcessingInfo dmInfo = new DMProcessingInfo();
 				int dmErrorCode = 0;
-				dmErrorCode = DMInterface.processGetValue("cmi.exit", true, true, dataManager, dmInfo);
+				dmErrorCode = DMInterface.processGetValue(CMI_EXIT, true, true, dataManager, dmInfo);
 				String exitValue = dmInfo.mValue;
 
 				if (dmErrorCode == APIErrorCodes.NO_ERROR)

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormContentServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormContentServiceImpl.java
@@ -35,7 +35,7 @@ import org.adl.validator.contentpackage.CPValidator;
 
 import org.apache.commons.lang.StringUtils;
 
-import org.sakaiproject.scorm.api.ScormConstants;
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.scorm.dao.LearnerDao;
 import org.sakaiproject.scorm.dao.api.ContentPackageDao;
 import org.sakaiproject.scorm.dao.api.ContentPackageManifestDao;
@@ -215,31 +215,31 @@ public abstract class ScormContentServiceImpl implements ScormContentService
 	@Override
 	public int getContentPackageStatus(ContentPackage contentPackage)
 	{
-		int status = ScormConstants.CONTENT_PACKAGE_STATUS_UNKNOWN;
+		int status = CONTENT_PACKAGE_STATUS_UNKNOWN;
 		Date now = new Date();
 
 		if (now.after(contentPackage.getReleaseOn()))
 		{
 			if (contentPackage.getDueOn() == null || contentPackage.getAcceptUntil() == null)
 			{
-				status = ScormConstants.CONTENT_PACKAGE_STATUS_OPEN;
+				status = CONTENT_PACKAGE_STATUS_OPEN;
 			}
 			else if (now.before(contentPackage.getDueOn()))
 			{
-				status = ScormConstants.CONTENT_PACKAGE_STATUS_OPEN;
+				status = CONTENT_PACKAGE_STATUS_OPEN;
 			}
 			else if (now.before(contentPackage.getAcceptUntil()))
 			{
-				status = ScormConstants.CONTENT_PACKAGE_STATUS_OVERDUE;
+				status = CONTENT_PACKAGE_STATUS_OVERDUE;
 			}
 			else
 			{
-				status = ScormConstants.CONTENT_PACKAGE_STATUS_CLOSED;
+				status = CONTENT_PACKAGE_STATUS_CLOSED;
 			}
 		}
 		else
 		{
-			status = ScormConstants.CONTENT_PACKAGE_STATUS_NOTYETOPEN;
+			status = CONTENT_PACKAGE_STATUS_NOTYETOPEN;
 		}
 
 		return status;
@@ -345,10 +345,10 @@ public abstract class ScormContentServiceImpl implements ScormContentService
 	public int validate(String resourceId, boolean isManifestOnly, boolean isValidateToSchema, String encoding, boolean createContentPackage) throws ResourceStorageException
 	{
 		File file = createFile(resourceService().getArchiveStream(resourceId));
-		int result = ScormConstants.VALIDATION_SUCCESS;
+		int result = VALIDATION_SUCCESS;
 		if (!file.exists())
 		{
-			return ScormConstants.VALIDATION_NOFILE;
+			return VALIDATION_NOFILE;
 		}
 
 		IValidator validator = validate(file, isManifestOnly, isValidateToSchema, encoding);
@@ -356,34 +356,34 @@ public abstract class ScormContentServiceImpl implements ScormContentService
 
 		if (!validatorOutcome.getDoesIMSManifestExist())
 		{
-			return ScormConstants.VALIDATION_NOMANIFEST;
+			return VALIDATION_NOMANIFEST;
 		}
 
 		if (!validatorOutcome.getIsWellformed())
 		{
-			result = ScormConstants.VALIDATION_NOTWELLFORMED;
+			result = VALIDATION_NOTWELLFORMED;
 		}
 
 		if (!validatorOutcome.getIsValidRoot())
 		{
-			result = ScormConstants.VALIDATION_NOTVALIDROOT;
+			result = VALIDATION_NOTVALIDROOT;
 		}
 
 		if (isValidateToSchema)
 		{
 			if (!validatorOutcome.getIsValidToSchema())
 			{
-				result = ScormConstants.VALIDATION_NOTVALIDSCHEMA;
+				result = VALIDATION_NOTVALIDSCHEMA;
 			}
 
 			if (!validatorOutcome.getIsValidToApplicationProfile())
 			{
-				result = ScormConstants.VALIDATION_NOTVALIDPROFILE;
+				result = VALIDATION_NOTVALIDPROFILE;
 			}
 
 			if (!validatorOutcome.getDoRequiredCPFilesExist())
 			{
-				result = ScormConstants.VALIDATION_MISSINGREQUIREDFILES;
+				result = VALIDATION_MISSINGREQUIREDFILES;
 			}
 		}
 
@@ -395,12 +395,12 @@ public abstract class ScormContentServiceImpl implements ScormContentService
 			}
 			catch (InvalidArchiveException iae)
 			{
-				return ScormConstants.VALIDATION_WRONGMIMETYPE;
+				return VALIDATION_WRONGMIMETYPE;
 			}
 			catch (Exception e)
 			{
 				log.error("Failed to convert content package for resourceId: {}", resourceId, e);
-				return ScormConstants.VALIDATION_CONVERTFAILED;
+				return VALIDATION_CONVERTFAILED;
 			}
 		}
 

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormResultServiceImpl.java
@@ -28,9 +28,8 @@ import org.adl.datamodels.DMInterface;
 import org.adl.datamodels.DMProcessingInfo;
 import org.adl.datamodels.IDataManager;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.apache.commons.lang.StringUtils;
-
-import org.sakaiproject.scorm.api.ScormConstants;
 import org.sakaiproject.scorm.dao.LearnerDao;
 import org.sakaiproject.scorm.dao.api.AttemptDao;
 import org.sakaiproject.scorm.dao.api.DataManagerDao;
@@ -52,7 +51,7 @@ import org.sakaiproject.scorm.service.api.ScormResultService;
 @Slf4j
 public abstract class ScormResultServiceImpl implements ScormResultService
 {
-	private static String[] fields = { "cmi.completion_status", "cmi.score.scaled", "cmi.success_status" };
+	private static String[] fields = { CMI_COMPLETION_STATUS, CMI_SCORE_SCALED, CMI_SUCCESS_STATUS };
 
 	// Daos (also depedency injected)
 	protected abstract AttemptDao attemptDao();
@@ -263,37 +262,37 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 		CMIFieldGroup group = new CMIFieldGroup();
 
 		List<CMIField> list = group.getList();
-		list.add(new CMIField("cmi.completion_status", "Completion Status"));
-		list.add(new CMIField("cmi.completion_threshold", "Completion Threshold"));
-		list.add(new CMIField("cmi.credit", "Will credit be given?"));
-		list.add(new CMIField("cmi.entry", "Has user previously accessed this sco?"));
-		list.add(new CMIField("cmi.exit", "Exit Type"));
+		list.add(new CMIField(CMI_COMPLETION_STATUS, "Completion Status"));
+		list.add(new CMIField(CMI_COMPLETION_THRESHOLD, "Completion Threshold"));
+		list.add(new CMIField(CMI_CREDIT, "Will credit be given?"));
+		list.add(new CMIField(CMI_ENTRY, "Has user previously accessed this sco?"));
+		list.add(new CMIField(CMI_EXIT, "Exit Type"));
 
 		// Interactions?
-		list.add(new CMIField("cmi.launch_data", "Initialization launch data"));
-		list.add(new CMIField("cmi.learner_id", "Learner Id"));
-		list.add(new CMIField("cmi.learner_name", "Learner Name"));
+		list.add(new CMIField(CMI_LAUNCH_DATA, "Initialization launch data"));
+		list.add(new CMIField(CMI_LEARNER_ID, "Learner Id"));
+		list.add(new CMIField(CMI_LEARNER_NAME, "Learner Name"));
 
 		// Learner preferences?
-		list.add(new CMIField("cmi.location", "Current location in the sco"));
-		list.add(new CMIField("cmi.max_time_allowed", "Maximum time allowed to use sco"));
-		list.add(new CMIField("cmi.mode", "Mode"));
-		list.add(new CMIField("cmi.progress_measure", "Progress Measure"));
-		list.add(new CMIField("cmi.scaled_passing_score", "Scaled passing score required"));
-		list.add(new CMIField("cmi.score.scaled", "Overall Scaled Score"));
-		list.add(new CMIField("cmi.score.raw", "Overall Raw Score"));
-		list.add(new CMIField("cmi.score.min", "Minimum Raw Score"));
-		list.add(new CMIField("cmi.score.max", "Maximum Raw Score"));
-		list.add(new CMIField("cmi.session_time", "Current learner session time"));
-		list.add(new CMIField("cmi.success_status", "Success Status"));
-		list.add(new CMIField("cmi.suspend_data", "Suspend data"));
-		list.add(new CMIField("cmi.time_limit_action", "Action when time expires"));
-		list.add(new CMIField("cmi.total_time", "Sum of learner's session times in attempt"));
+		list.add(new CMIField(CMI_LOCATION, "Current location in the sco"));
+		list.add(new CMIField(CMI_MAX_TIME_ALLOWED, "Maximum time allowed to use sco"));
+		list.add(new CMIField(CMI_MODE, "Mode"));
+		list.add(new CMIField(CMI_PROGRESS_MEASURE, "Progress Measure"));
+		list.add(new CMIField(CMI_SCALED_PASSING_SCORE, "Scaled passing score required"));
+		list.add(new CMIField(CMI_SCORE_SCALED, "Overall Scaled Score"));
+		list.add(new CMIField(CMI_SCORE_RAW, "Overall Raw Score"));
+		list.add(new CMIField(CMI_SCORE_MIN, "Minimum Raw Score"));
+		list.add(new CMIField(CMI_SCORE_MAX, "Maximum Raw Score"));
+		list.add(new CMIField(CMI_SESSION_TIME, "Current learner session time"));
+		list.add(new CMIField(CMI_SUCCESS_STATUS, "Success Status"));
+		list.add(new CMIField(CMI_SUSPEND_DATA, "Suspend data"));
+		list.add(new CMIField(CMI_TIME_LIMIT_ACTION, "Action when time expires"));
+		list.add(new CMIField(CMI_TOTAL_TIME, "Sum of learner's session times in attempt"));
 
-		list.add(new CMIField("cmi.timestamp", "Timestamp"));
-		list.add(new CMIField("cmi.comments_from_learner", "Comments from Learner"));
-		list.add(new CMIField("cmi.objectives._count", "Objective count"));
-		list.add(new CMIField("cmi.interactions._count", "Interaction count"));
+		list.add(new CMIField(CMI_TIMESTAMP, "Timestamp"));
+		list.add(new CMIField(CMI_COMMENTS_FROM_LEARNER, "Comments from Learner"));
+		list.add(new CMIField(CMI_OBJECTIVES_COUNT, "Objective count"));
+		list.add(new CMIField(CMI_INTERACTIONS_COUNT, "Interaction count"));
 
 		CMIField objectives = new CMIField("cmi.objectives", "Objectives");
 		objectives.addChild(new CMIField("id", "Objective Id"));
@@ -351,7 +350,7 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 			Learner learner = learners.get(i);
 			LearnerExperience experience = new LearnerExperience(learner, contentPackageId);
 			List<Attempt> attempts = getAttempts(contentPackageId, learner.getId());
-			int status = ScormConstants.NOT_ACCESSED;
+			int status = NOT_ACCESSED;
 
 			if (attempts != null)
 			{
@@ -362,7 +361,7 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 
 					//List<CMIData> data = getSummaryCMIData(latestAttempt);
 					experience.setLastAttemptDate(latestAttempt.getBeginDate());
-					status = ScormConstants.COMPLETED;
+					status = COMPLETED;
 				}
 
 				experience.setNumberOfAttempts(attempts.size());
@@ -535,11 +534,11 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 	{
 		CMIFieldGroup group = new CMIFieldGroup();
 		List<CMIField> list = group.getList();
-		list.add(new CMIField("cmi.score.scaled", "Overall Scaled Score"));
-		list.add(new CMIField("cmi.completion_status", "Completion Status"));
-		list.add(new CMIField("cmi.success_status", "Success Status"));
-		list.add(new CMIField("cmi.completion_threshold", "Completion Threshold"));
-		list.add(new CMIField("cmi.progress_measure", "Progress Measure"));
+		list.add(new CMIField(CMI_SCORE_SCALED, "Overall Scaled Score"));
+		list.add(new CMIField(CMI_COMPLETION_STATUS, "Completion Status"));
+		list.add(new CMIField(CMI_SUCCESS_STATUS, "Success Status"));
+		list.add(new CMIField(CMI_COMPLETION_THRESHOLD, "Completion Threshold"));
+		list.add(new CMIField(CMI_PROGRESS_MEASURE, "Progress Measure"));
 		return group;
 	}
 
@@ -600,7 +599,7 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 
 	private void mapInteractions(List<Interaction> interactions, IDataManager dataManager, long contentPackageId, String learnerId, long attemptNumber, boolean onlyIds)
 	{
-		int numberOfInteractions = getValueAsInt("cmi.interactions._count", dataManager);
+		int numberOfInteractions = getValueAsInt(CMI_INTERACTIONS_COUNT, dataManager);
 		for (int i = 0; i < numberOfInteractions; i++)
 		{
 			Interaction interaction = new Interaction();
@@ -610,7 +609,7 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 			interaction.setLearnerId(learnerId);
 			interaction.setScoId(dataManager.getScoId());
 
-			String interactionName = new StringBuilder("cmi.interactions.").append(i).append(".").toString();
+			String interactionName = new StringBuilder(CMI_INTERACTIONS_ROOT).append(i).append(".").toString();
 			String interactionIdName = new StringBuilder(interactionName).append("id").toString();
 			interaction.setInteractionId(getValueAsString(interactionIdName, dataManager));
 
@@ -665,11 +664,11 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 
 	private void mapObjectives(Map<String, Objective> objectives, IDataManager dataManager, long contentPackageId, String learnerId, long attemptNumber)
 	{
-		int numberOfObjectives = getValueAsInt("cmi.objectives._count", dataManager);
+		int numberOfObjectives = getValueAsInt(CMI_OBJECTIVES_COUNT, dataManager);
 		for (int i = 0; i < numberOfObjectives; i++)
 		{
 			Objective objective = new Objective();
-			String objectiveName = new StringBuilder("cmi.objectives.").append(i).append(".").toString();
+			String objectiveName = new StringBuilder(CMI_OBJECTIVES_ROOT).append(i).append(".").toString();
 
 			String objectiveIdName = new StringBuilder(objectiveName).append("id").toString();
 			objective.setId(getValueAsString(objectiveIdName, dataManager));
@@ -711,21 +710,21 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 	private void mapValues(ActivityReport report, IDataManager dataManager, long contentPackageId, String learnerId, long attemptNumber)
 	{
 		Progress progress = new Progress();
-		progress.setProgressMeasure(getRealValue("cmi.progress_measure", dataManager));
-		progress.setCompletionThreshold(getRealValue("cmi.completion_threshold", dataManager));
-		progress.setLearnerLocation(getValueAsString("cmi.location", dataManager));
-		progress.setSuccessStatus(getValueAsString("cmi.success_status", dataManager));
-		progress.setCompletionStatus(getValueAsString("cmi.completion_status", dataManager));
-		progress.setMaxSecondsAllowed(getRealValueAsInt("cmi.max_time_allowed", dataManager));
-		progress.setTotalSessionSeconds(getValueAsString("cmi.total_time", dataManager));
+		progress.setProgressMeasure(getRealValue(CMI_PROGRESS_MEASURE, dataManager));
+		progress.setCompletionThreshold(getRealValue(CMI_COMPLETION_THRESHOLD, dataManager));
+		progress.setLearnerLocation(getValueAsString(CMI_LOCATION, dataManager));
+		progress.setSuccessStatus(getValueAsString(CMI_SUCCESS_STATUS, dataManager));
+		progress.setCompletionStatus(getValueAsString(CMI_COMPLETION_STATUS, dataManager));
+		progress.setMaxSecondsAllowed(getRealValueAsInt(CMI_MAX_TIME_ALLOWED, dataManager));
+		progress.setTotalSessionSeconds(getValueAsString(CMI_TOTAL_TIME, dataManager));
 		report.setProgress(progress);
 
 		Score score = new Score();
-		score.setScaled(getRealValue("cmi.score.scaled", dataManager));
-		score.setRaw(getRealValue("cmi.score.raw", dataManager));
-		score.setMin(getRealValue("cmi.score.min", dataManager));
-		score.setMax(getRealValue("cmi.score.max", dataManager));
-		score.setScaledToPass(getRealValue("cmi.score.scaled_passing_score", dataManager));
+		score.setScaled(getRealValue(CMI_SCORE_SCALED, dataManager));
+		score.setRaw(getRealValue(CMI_SCORE_RAW, dataManager));
+		score.setMin(getRealValue(CMI_SCORE_MIN, dataManager));
+		score.setMax(getRealValue(CMI_SCORE_MAX, dataManager));
+		score.setScaledToPass(getRealValue(CMI_SCORE_SCALED + "_passing_score", dataManager));
 		report.setScore(score);
 
 		List<Interaction> interactions = report.getInteractions();
@@ -751,19 +750,19 @@ public abstract class ScormResultServiceImpl implements ScormResultService
 
 	private void mapValues(ActivitySummary summary, IDataManager dataManager)
 	{
-		summary.setProgressMeasure(getRealValue("cmi.progress_measure", dataManager));
-		summary.setCompletionThreshold(getRealValue("cmi.completion_threshold", dataManager));
-		summary.setLearnerLocation(getValueAsString("cmi.location", dataManager));
-		summary.setSuccessStatus(getValueAsString("cmi.success_status", dataManager));
-		summary.setCompletionStatus(getValueAsString("cmi.completion_status", dataManager));
-		summary.setMaxSecondsAllowed(getRealValueAsInt("cmi.max_time_allowed", dataManager));
-		summary.setTotalSessionSeconds(getValueAsString("cmi.total_time", dataManager));
+		summary.setProgressMeasure(getRealValue(CMI_PROGRESS_MEASURE, dataManager));
+		summary.setCompletionThreshold(getRealValue(CMI_COMPLETION_THRESHOLD, dataManager));
+		summary.setLearnerLocation(getValueAsString(CMI_LOCATION, dataManager));
+		summary.setSuccessStatus(getValueAsString(CMI_SUCCESS_STATUS, dataManager));
+		summary.setCompletionStatus(getValueAsString(CMI_COMPLETION_STATUS, dataManager));
+		summary.setMaxSecondsAllowed(getRealValueAsInt(CMI_MAX_TIME_ALLOWED, dataManager));
+		summary.setTotalSessionSeconds(getValueAsString(CMI_TOTAL_TIME, dataManager));
 
-		summary.setScaled(getRealValue("cmi.score.scaled", dataManager));
-		summary.setRaw(getRealValue("cmi.score.raw", dataManager));
-		summary.setMin(getRealValue("cmi.score.min", dataManager));
-		summary.setMax(getRealValue("cmi.score.max", dataManager));
-		summary.setScaledToPass(getRealValue("cmi.score.scaled_passing_score", dataManager));
+		summary.setScaled(getRealValue(CMI_SCORE_SCALED, dataManager));
+		summary.setRaw(getRealValue(CMI_SCORE_RAW, dataManager));
+		summary.setMin(getRealValue(CMI_SCORE_MIN, dataManager));
+		summary.setMax(getRealValue(CMI_SCORE_MAX, dataManager));
+		summary.setScaledToPass(getRealValue(CMI_SCORE_SCALED + "_passing_score", dataManager));
 	}
 
 	private List<CMIData> populateData(CMIField field, IDataManager dataManager)

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
@@ -12,6 +12,7 @@
 				<lookup-method name="attemptDao" bean="org.sakaiproject.scorm.dao.api.AttemptDao" />
 				<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
 				<lookup-method name="gradebookExternalAssessmentService" bean="org.sakaiproject.service.gradebook.GradebookExternalAssessmentService" />
+				<lookup-method name="gradebookService" bean="org.sakaiproject.service.gradebook.GradebookService" />
 				<lookup-method name="learnerDao" bean="org.sakaiproject.scorm.dao.LearnerDao" />
 				<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
 			</bean>

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/MockLearningManagementSystem.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/MockLearningManagementSystem.java
@@ -16,7 +16,7 @@
 package org.sakaiproject.scorm.service.sakai.impl;
 
 
-import org.sakaiproject.scorm.api.ScormConstants;
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.scorm.exceptions.LearnerNotDefinedException;
 import org.sakaiproject.scorm.model.api.ContentPackage;
 import org.sakaiproject.scorm.model.api.Learner;
@@ -28,24 +28,24 @@ public class MockLearningManagementSystem implements LearningManagementSystem
 	@Override
 	public boolean canConfigure(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_CONFIG);
+		return hasPermission(context, PERM_CONFIG);
 	}
 
 	@Override
 	public boolean canDelete(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_DELETE);
+		return hasPermission(context, PERM_DELETE);
 	}
 
 	@Override
 	public boolean canGrade(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_GRADE);
+		return hasPermission(context, PERM_GRADE);
 	}
 
 	public boolean canLaunch(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_LAUNCH);
+		return hasPermission(context, PERM_LAUNCH);
 	}
 
 	@Override
@@ -63,7 +63,7 @@ public class MockLearningManagementSystem implements LearningManagementSystem
 	@Override
 	public boolean canUpload(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_UPLOAD);
+		return hasPermission(context, PERM_UPLOAD);
 	}
 
 	@Override
@@ -74,13 +74,13 @@ public class MockLearningManagementSystem implements LearningManagementSystem
 	@Override
 	public boolean canValidate(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_VALIDATE);
+		return hasPermission(context, PERM_VALIDATE);
 	}
 
 	@Override
 	public boolean canViewResults(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_VIEW_RESULTS);
+		return hasPermission(context, PERM_VIEW_RESULTS);
 	}
 
 	@Override

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiStatefulService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiStatefulService.java
@@ -19,9 +19,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.authz.api.SecurityService;
 import org.sakaiproject.component.api.ServerConfigurationService;
-import org.sakaiproject.scorm.api.ScormConstants;
 import org.sakaiproject.scorm.dao.LearnerDao;
 import org.sakaiproject.scorm.exceptions.LearnerNotDefinedException;
 import org.sakaiproject.scorm.model.api.ContentPackage;
@@ -56,19 +56,19 @@ public abstract class SakaiStatefulService implements LearningManagementSystem
 	@Override
 	public boolean canConfigure(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_CONFIG);
+		return hasPermission(context, PERM_CONFIG);
 	}
 
 	@Override
 	public boolean canDelete(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_DELETE);
+		return hasPermission(context, PERM_DELETE);
 	}
 
 	@Override
 	public boolean canGrade(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_GRADE);
+		return hasPermission(context, PERM_GRADE);
 	}
 
 	@Override
@@ -95,10 +95,10 @@ public abstract class SakaiStatefulService implements LearningManagementSystem
 		{
 			return true;
 		}
-		else if (hasPermission(context, ScormConstants.PERM_LAUNCH))
+		else if (hasPermission(context, PERM_LAUNCH))
 		{
 			int status = scormContentService().getContentPackageStatus(contentPackage);
-			if (status != ScormConstants.CONTENT_PACKAGE_STATUS_OPEN && status != ScormConstants.CONTENT_PACKAGE_STATUS_OVERDUE)
+			if (status != CONTENT_PACKAGE_STATUS_OPEN && status != CONTENT_PACKAGE_STATUS_OVERDUE)
 			{
 				return false;
 			}
@@ -137,7 +137,7 @@ public abstract class SakaiStatefulService implements LearningManagementSystem
 	@Override
 	public boolean canUpload(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_UPLOAD);
+		return hasPermission(context, PERM_UPLOAD);
 	}
 
 	@Override
@@ -149,13 +149,13 @@ public abstract class SakaiStatefulService implements LearningManagementSystem
 	@Override
 	public boolean canValidate(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_VALIDATE);
+		return hasPermission(context, PERM_VALIDATE);
 	}
 
 	@Override
 	public boolean canViewResults(String context)
 	{
-		return hasPermission(context, ScormConstants.PERM_VIEW_RESULTS);
+		return hasPermission(context, PERM_VIEW_RESULTS);
 	}
 
 	@Override

--- a/scorm-tool/pom.xml
+++ b/scorm-tool/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AccessStatusColumn.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/components/AccessStatusColumn.java
@@ -21,8 +21,7 @@ import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 
-import org.sakaiproject.scorm.api.ScormConstants;
-
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.scorm.model.api.LearnerExperience;
 
 public class AccessStatusColumn extends AbstractColumn
@@ -51,16 +50,16 @@ public class AccessStatusColumn extends AbstractColumn
 
 			switch (experience.getStatus())
 			{
-				case ScormConstants.NOT_ACCESSED:
+				case NOT_ACCESSED:
 					resourceId = "access.status.not.accessed";
 					break;
-				case ScormConstants.INCOMPLETE:
+				case INCOMPLETE:
 					resourceId = "access.status.incomplete";
 					break;
-				case ScormConstants.COMPLETED:
+				case COMPLETED:
 					resourceId = "access.status.completed";
 					break;
-				case ScormConstants.GRADED:
+				case GRADED:
 					resourceId = "access.status.graded";
 					break;
 			};

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
@@ -9,13 +9,17 @@ form.label.last.changed.on            = Last Changed On:
 form.label.number.of.tries            = Number Of Tries:
 form.label.open.date                  = Open Date:
 form.label.package.name               = Name:
-form.label.synchronyse.with.gradebook = Synchronize score to Gradebook
-form.label.hide.toc                   = Hide Table of Contents
+form.label.synchronyse.with.gradebook = Synchronize score to Gradebook:
+form.label.hide.toc                   = Hide Table of Contents:
 
 form.error.dueDateBeforeOpenDate      = The Due Date cannot be set before the Open Date. Please select a different Due Date.
+form.error.gradebook.noGradebook = A Gradebook connection cannot be made for this module because there is no Gradebook in this site.
+form.error.gradebook.assessmentNotFound = The corresponding Gradebook item could not be located. Please try again.
+form.error.gradebook.conflictingName = A Gradebook item with this name already exists. Please edit the name below and try again.
+form.error.gradebook.invalidPoints = The total point value of this module is incompatible with the Gradebook.
 
 page.title = Configure Learning Content Package
 
 unlimited = Unlimited
 
-verify.synchronizeWithGradebook = Are you sure you want to remove the gradebook integration for this sub-module? All grades associated with this sub-module will be deleted.
+verify.synchronizeWithGradebook = Are you sure you want to remove the gradebook connection for this sub-module? All grades associated with this sub-module will be deleted.

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageListPage.java
@@ -39,7 +39,7 @@ import org.apache.wicket.request.resource.PackageResourceReference;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.string.StringValue;
 
-import org.sakaiproject.scorm.api.ScormConstants;
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.scorm.model.api.ContentPackage;
 import org.sakaiproject.scorm.service.api.LearningManagementSystem;
 import org.sakaiproject.scorm.service.api.ScormContentService;
@@ -189,16 +189,16 @@ public class PackageListPage extends ConsoleBasePage
 
 				switch (status)
 				{
-					case ScormConstants.CONTENT_PACKAGE_STATUS_OPEN:
+					case CONTENT_PACKAGE_STATUS_OPEN:
 						resourceId = "status.open";
 						break;
-					case ScormConstants.CONTENT_PACKAGE_STATUS_OVERDUE:
+					case CONTENT_PACKAGE_STATUS_OVERDUE:
 						resourceId = "status.overdue";
 						break;
-					case ScormConstants.CONTENT_PACKAGE_STATUS_CLOSED:
+					case CONTENT_PACKAGE_STATUS_CLOSED:
 						resourceId = "status.closed";
 						break;
-					case ScormConstants.CONTENT_PACKAGE_STATUS_NOTYETOPEN:
+					case CONTENT_PACKAGE_STATUS_NOTYETOPEN:
 						resourceId = "status.notyetopen";
 						break;
 				}

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/reporting/pages/ResultsListPage.java
@@ -42,7 +42,7 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.file.Files;
 
-import org.sakaiproject.scorm.api.ScormConstants;
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.scorm.model.api.ActivityReport;
 import org.sakaiproject.scorm.model.api.ActivitySummary;
 import org.sakaiproject.scorm.model.api.ContentPackage;
@@ -311,19 +311,19 @@ public class ResultsListPage extends ConsoleBasePage
 	{
 		switch( status )
 		{
-			case ScormConstants.NOT_ACCESSED:
+			case NOT_ACCESSED:
 			{
 				return getLocalizer().getString( "access.status.not.accessed", this );
 			}
-			case ScormConstants.INCOMPLETE:
+			case INCOMPLETE:
 			{
 				return getLocalizer().getString( "access.status.incomplete", this );
 			}
-			case ScormConstants.COMPLETED:
+			case COMPLETED:
 			{
 				return getLocalizer().getString( "access.status.completed", this );
 			}
-			case ScormConstants.GRADED:
+			case GRADED:
 			{
 				return getLocalizer().getString( "access.status.graded", this );
 			}

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/UploadPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/UploadPage.java
@@ -33,6 +33,7 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.lang.Bytes;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
 import org.sakaiproject.component.api.ServerConfigurationService;
 import org.sakaiproject.event.api.NotificationService;
 import org.sakaiproject.exception.IdInvalidException;
@@ -41,7 +42,6 @@ import org.sakaiproject.exception.IdUniquenessException;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.OverQuotaException;
 import org.sakaiproject.exception.PermissionException;
-import org.sakaiproject.scorm.api.ScormConstants;
 import org.sakaiproject.scorm.service.api.ScormContentService;
 import org.sakaiproject.scorm.service.api.ScormResourceService;
 import org.sakaiproject.scorm.ui.console.pages.ConsoleBasePage;
@@ -149,7 +149,7 @@ public class UploadPage extends ConsoleBasePage
                                 String resourceId = resourceService.putArchive( upload.getInputStream(), upload.getClientFileName(), upload.getContentType(), false, NotificationService.NOTI_NONE );
                                 int status = contentService.storeAndValidate( resourceId, false, serverConfigurationService.getString( "scorm.zip.encoding", "UTF-8" ) );
 
-                                if( status == ScormConstants.VALIDATION_SUCCESS )
+                                if( status == VALIDATION_SUCCESS )
                                 {
                                     PageParameters params = new PageParameters();
                                     params.add( "uploadSuccess", MessageFormat.format( getString( "upload.success" ), upload.getClientFileName() ) );
@@ -231,21 +231,21 @@ public class UploadPage extends ConsoleBasePage
     {
         switch( status )
         {
-            case ScormConstants.VALIDATION_WRONGMIMETYPE:
+            case VALIDATION_WRONGMIMETYPE:
                 return "validate.wrong.mime.type";
-            case ScormConstants.VALIDATION_NOFILE:
+            case VALIDATION_NOFILE:
                 return "validate.no.file";
-            case ScormConstants.VALIDATION_NOMANIFEST:
+            case VALIDATION_NOMANIFEST:
                 return "validate.no.manifest";
-            case ScormConstants.VALIDATION_NOTWELLFORMED:
+            case VALIDATION_NOTWELLFORMED:
                 return "validate.not.well.formed";
-            case ScormConstants.VALIDATION_NOTVALIDROOT:
+            case VALIDATION_NOTVALIDROOT:
                 return "validate.not.valid.root";
-            case ScormConstants.VALIDATION_NOTVALIDSCHEMA:
+            case VALIDATION_NOTVALIDSCHEMA:
                 return "validate.not.valid.schema";
-            case ScormConstants.VALIDATION_NOTVALIDPROFILE:
+            case VALIDATION_NOTVALIDPROFILE:
                 return "validate.not.valid.profile";
-            case ScormConstants.VALIDATION_MISSINGREQUIREDFILES:
+            case VALIDATION_MISSINGREQUIREDFILES:
                 return "validate.missing.files";
             default:
                 return "upload.failed";

--- a/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/SCORM13APITest.java
+++ b/scorm-tool/src/test/org/sakaiproject/scorm/ui/player/behaviors/SCORM13APITest.java
@@ -19,6 +19,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.sakaiproject.scorm.api.ScormConstants.*;
+
 public class SCORM13APITest extends AbstractSCORM13APBase
 {
 	@Before
@@ -32,27 +34,27 @@ public class SCORM13APITest extends AbstractSCORM13APBase
 	public void testSimple()
 	{
 		Assert.assertEquals("true", scorm13api.Initialize(""));
-		Assert.assertEquals("OBJ_FLASH", scorm13api.GetValue("cmi.objectives.0.id"));
-		Assert.assertEquals("OBJ_DIRECTOR", scorm13api.GetValue("cmi.objectives.1.id"));
+		Assert.assertEquals("OBJ_FLASH", scorm13api.GetValue(CMI_OBJECTIVES_ROOT + "0.id"));
+		Assert.assertEquals("OBJ_DIRECTOR", scorm13api.GetValue(CMI_OBJECTIVES_ROOT+ "1.id"));
 
 		// Count
-		Assert.assertEquals("2", scorm13api.GetValue("cmi.objectives._count"));
+		Assert.assertEquals("2", scorm13api.GetValue(CMI_OBJECTIVES_COUNT));
 
 		// 301
-		Assert.assertEquals("false", scorm13api.SetValue("cmi.interactions.1.id", "koe"));
+		Assert.assertEquals("false", scorm13api.SetValue(CMI_INTERACTIONS_ROOT + "1.id", "koe"));
 		Assert.assertEquals("301", scorm13api.GetLastError());
 
 		// Count
-		Assert.assertEquals("0", scorm13api.GetValue("cmi.interactions._count"));
+		Assert.assertEquals("0", scorm13api.GetValue(CMI_INTERACTIONS_COUNT));
 
 		// Ok
-		Assert.assertEquals("true", scorm13api.SetValue("cmi.interactions.0.id", "koe"));
+		Assert.assertEquals("true", scorm13api.SetValue(CMI_INTERACTIONS_ROOT + "0.id", "koe"));
 		Assert.assertEquals("0", scorm13api.GetLastError());
 
 		// Count
-		Assert.assertEquals("1", scorm13api.GetValue("cmi.interactions._count"));
+		Assert.assertEquals("1", scorm13api.GetValue(CMI_INTERACTIONS_COUNT));
 
-		scorm13api.SetValue("cmi.session_time", "PT1H5M");
+		scorm13api.SetValue(CMI_SESSION_TIME, "PT1H5M");
 		scorm13api.Commit("");
 		scorm13api.SetValue("does.not.extist", "que");
 		scorm13api.Terminate("");

--- a/wicket-tool/pom.xml
+++ b/wicket-tool/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.sakaiproject</groupId>
+        <groupId>org.sakaiproject.scorm</groupId>
         <artifactId>scorm-base</artifactId>
         <version>20-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-163

*NOTE:* this code is dependent on changes in edu-services in core Sakai, introduced here: https://github.com/sakaiproject/sakai/pull/7422 ([SAK-42613](https://jira.sakaiproject.org/browse/SAK-42613))

We've seen that with some modules, when gradebook synchronization is enabled, a score of -100 is sent to the gradebook.

In my investigation, I've found this happens because:

* some modules do not communicate the value of "cmi.score.scaled" to the LMS before, during, or after a module is completed
* in `ScormApplicationServiceImpl.java`, when gradebook synchronization is enabled, it attempts to load the "cmi.score.scaled" value from the database for the given module and student
** if this value cannot be retrieved from the database, the code simply sets the value to -1
** the synchronization code then continues, multiples -1 by 100 resulting in -100, and pushes this grade to the gradebook

Now, we can't just force all grades sent to the gradebook to be positive values, because according to the SCORM specifications [1], negative values are perfectly valid and represent real use cases.

We also can't address the problem in the module via SCORM Player code, because that's not in our control.

The solution to this problem is to refactor the algorithm responsible for retrieving the "cmi.score.scaled" value to instead return an `OptionalDouble` rather than a primitive `double`. In this way, if the value of "cmi.score.scaled" is not recorded we can pass an empty `OptionalDouble`, and we can check for the presence or absence of the value when the gradebook synchronization code runs.

If we get an empty `OptionalDouble`, we will not push a grade to the gradebook, but rather push a comment to the gradebook item cell indicating that "This SCORM module did not record any grading data."

If we get an `OptionalDouble` which contains a real value, then we can scale it and push it to the gradebook normally.

If in a multiple attempt scenario and the "problem" with the module is either resolved or simply a point in time issue between the first attempt and subsequent attempts, the algorithm will detect that a real value has been recorded for "cmi.score.scaled" on subsequent attempts and will push the scaled grade to the gradebook and will also remove the old comment about the module not recording grading data.

[1] https://scorm.com/scorm-explained/technical-scorm/run-time/run-time-reference/