### PR TITLE
SCO-164: configure > gradebook checkboxes and labels are not connected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,6 @@
     <parent>
         <groupId>org.sakaiproject</groupId>
         <artifactId>master</artifactId>
-        <relativePath>../master/pom.xml</relativePath>
         <version>20-SNAPSHOT</version>
     </parent>
 
@@ -87,6 +86,31 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>snapshots</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>snapshots</name>
+                </property>
+            </activation>
+            <repositories>
+                <repository>
+                    <id>sonatype-nexus-snapshots</id>
+                    <name>Sonatype Nexus Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.html
@@ -72,7 +72,7 @@
 						<div wicket:id="verifySyncWithGradebook" class="sak-banner-warn">
 							<wicket:message key="verify.synchronizeWithGradebook"></wicket:message>
 						</div>
-						<label for="synchronizeSCOWithGradebook">
+						<label wicket:for="synchronizeSCOWithGradebook">
 							<wicket:message key="form.label.synchronyse.with.gradebook"></wicket:message>
 						</label>
 						<input type="checkbox" wicket:id="synchronizeSCOWithGradebook"></input>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-164

The check boxes for gradebook synchronization are in a repeater, but the for="" attribute on the labels is referencing a static, hard coded value. The result is that clicking on the labels does not select/deselect the corresponding checkbox.

This is super annoying. Fix it.