### PR TITLE
SCO-166: Fix entity linking

### DIFF
--- a/scorm-api/src/java/org/sakaiproject/scorm/api/ScormConstants.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/api/ScormConstants.java
@@ -110,4 +110,13 @@ public class ScormConstants
 
 	/** SCORM Player permission: view results */
 	public static final String PERM_VIEW_RESULTS = "scorm.view.results";
+
+	/** SCORM Player tool registration ID */
+	public static final String SCORM_TOOL_ID = "sakai.scorm.tool";
+
+	/** SCORM Player default tool name */
+	public static final String SCORM_DFLT_TOOL_NAME = "SCORM Player";
+
+	/** SCORM Player root directory in Resources */
+	public static final String ROOT_DIRECTORY = "/private/scorm/";
 }

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIFieldGroup.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/CMIFieldGroup.java
@@ -18,60 +18,14 @@ package org.sakaiproject.scorm.model.api;
 import java.util.LinkedList;
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+@EqualsAndHashCode
 public class CMIFieldGroup
 {
 	@Getter @Setter private Long id;
-	@Getter @Setter private long contentPackageId;
-	@Getter @Setter private List<CMIField> list;
-
-	public CMIFieldGroup()
-	{
-		this.list = new LinkedList<>();
-	}
-
-	@Override
-	public boolean equals(Object obj)
-	{
-		if (this == obj)
-		{
-			return true;
-		}
-
-		if (obj == null)
-		{
-			return false;
-		}
-
-		if (getClass() != obj.getClass())
-		{
-			return false;
-		}
-
-		CMIFieldGroup other = (CMIFieldGroup) obj;
-		if (id == null)
-		{
-			if (other.id != null)
-			{
-				return false;
-			}
-		}
-		else if (!id.equals(other.id))
-		{
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override
-	public int hashCode()
-	{
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
-	}
+	@EqualsAndHashCode.Exclude @Getter @Setter private long contentPackageId;
+	@EqualsAndHashCode.Exclude @Getter @Setter private List<CMIField> list = new LinkedList<>();
 }

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackage.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackage.java
@@ -20,9 +20,11 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+@EqualsAndHashCode
 public class ContentPackage implements Serializable
 {
 	private static final long serialVersionUID = 1L;
@@ -30,27 +32,26 @@ public class ContentPackage implements Serializable
 	private static final int NUMBER_OF_TRIES_UNLIMITED = -1;
 
 	@Getter @Setter private Long contentPackageId;
-	@Getter @Setter private String context;
-	@Getter @Setter private String title;
-	@Getter @Setter private String resourceId;
-	@Getter @Setter private String manifestResourceId;
-	@Getter @Setter private String url;
-	@Getter @Setter private String createdBy;
-	@Getter @Setter private String modifiedBy;
-	@Getter @Setter private Serializable manifestId;
-	@Getter @Setter private Date releaseOn;
-	@Getter @Setter private Date dueOn;
-	@Getter @Setter private Date acceptUntil;
-	@Getter @Setter private Date createdOn;
-	@Getter @Setter private Date modifiedOn;
-	@Getter @Setter private int numberOfTries = NUMBER_OF_TRIES_UNLIMITED;
-	@Getter @Setter private boolean isDeleted;
-	@Getter @Setter private boolean hideTOC = false; // default is to always show the table of contents
+	@EqualsAndHashCode.Exclude @Getter @Setter private String context;
+	@EqualsAndHashCode.Exclude @Getter @Setter private String title;
+	@EqualsAndHashCode.Exclude @Getter @Setter private String resourceId;
+	@EqualsAndHashCode.Exclude @Getter @Setter private String manifestResourceId;
+	@EqualsAndHashCode.Exclude @Getter @Setter private String url;
+	@EqualsAndHashCode.Exclude @Getter @Setter private String createdBy;
+	@EqualsAndHashCode.Exclude @Getter @Setter private String modifiedBy;
+	@EqualsAndHashCode.Exclude @Getter @Setter private Serializable manifestId;
+	@EqualsAndHashCode.Exclude @Getter @Setter private Date releaseOn;
+	@EqualsAndHashCode.Exclude @Getter @Setter private Date dueOn;
+	@EqualsAndHashCode.Exclude @Getter @Setter private Date acceptUntil;
+	@EqualsAndHashCode.Exclude @Getter @Setter private Date createdOn;
+	@EqualsAndHashCode.Exclude @Getter @Setter private Date modifiedOn;
+	@EqualsAndHashCode.Exclude @Getter @Setter private int numberOfTries = NUMBER_OF_TRIES_UNLIMITED;
+	@EqualsAndHashCode.Exclude @Getter @Setter private boolean isDeleted;
+	@EqualsAndHashCode.Exclude @Getter @Setter private boolean hideTOC = false; // default is to always show the table of contents
 
 	// This is not persisted to the database. It is only used in the context of configuring a content package, and thus
 	// only stores the session user's time zone id for display and getter/setter purposes.
-	@Getter @Setter
-	ZoneId sessionUserZoneID;
+	@EqualsAndHashCode.Exclude @Getter @Setter ZoneId sessionUserZoneID;
 
 	public ZonedDateTime getZonedReleaseOn()
 	{
@@ -109,11 +110,6 @@ public class ContentPackage implements Serializable
 		return now.after(releaseOn);
 	}
 
-	public String getStatus()
-	{
-		return "Open";
-	}
-
 	public ContentPackage()
 	{
 		this.isDeleted = false;
@@ -131,48 +127,5 @@ public class ContentPackage implements Serializable
 		this();
 		this.title = title;
 		this.resourceId = resourceId;
-	}
-
-	@Override
-	public boolean equals(Object obj)
-	{
-		if (this == obj)
-		{
-			return true;
-		}
-
-		if (obj == null)
-		{
-			return false;
-		}
-
-		if (getClass() != obj.getClass())
-		{
-			return false;
-		}
-
-		ContentPackage other = (ContentPackage) obj;
-		if (contentPackageId == null)
-		{
-			if (other.contentPackageId != null)
-			{
-				return false;
-			}
-		}
-		else if (!contentPackageId.equals(other.contentPackageId))
-		{
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override
-	public int hashCode()
-	{
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((contentPackageId == null) ? 0 : contentPackageId.hashCode());
-		return result;
 	}
 }

--- a/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageManifest.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/model/api/ContentPackageManifest.java
@@ -18,56 +18,22 @@ package org.sakaiproject.scorm.model.api;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 import org.adl.sequencer.ISeqActivityTree;
 import org.adl.validator.contentpackage.LaunchData;
 
+@EqualsAndHashCode
 public class ContentPackageManifest implements Serializable
 {
 	private static final long serialVersionUID = 1L;
 
-	@Getter @Setter private Long id;
+	@EqualsAndHashCode.Include @Getter @Setter private Long id;
 	@Getter @Setter private ISeqActivityTree actTreePrototype;
 	@Getter private List launchDataList;
 	private HashMap<String, LaunchData> launchDataMap;
-
-	public ContentPackageManifest() {}
-
-	@Override
-	public boolean equals(Object obj)
-	{
-		if (this == obj)
-		{
-			return true;
-		}
-
-		if (obj == null)
-		{
-			return false;
-		}
-
-		if (getClass() != obj.getClass())
-		{
-			return false;
-		}
-
-		ContentPackageManifest other = (ContentPackageManifest) obj;
-		if (id == null)
-		{
-			if (other.id != null)
-			{
-				return false;
-			}
-		}
-		else if (!id.equals(other.id))
-		{
-			return false;
-		}
-
-		return true;
-	}
 
 	public List getLaunchData()
 	{
@@ -77,15 +43,6 @@ public class ContentPackageManifest implements Serializable
 	public LaunchData getLaunchData(String identifier)
 	{
 		return launchDataMap.get(identifier);
-	}
-
-	@Override
-	public int hashCode()
-	{
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		return result;
 	}
 
 	public void setLaunchData(List launchDataList)

--- a/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/spring-hibernate-daos.xml
+++ b/scorm-impl/model/src/java/org/sakaiproject/scorm/dao/hibernate/spring-hibernate-daos.xml
@@ -4,47 +4,17 @@
 
 <beans>
 
-	<bean id="scorm.ActivityTreeHolderDaoTarget"
-		class="org.sakaiproject.scorm.dao.hibernate.ActivityTreeHolderDaoImpl">
-		<property name="sessionFactory">
-			<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
-		</property>
-	</bean>
-
-	<bean id="scorm.AttemptDaoTarget"
-		class="org.sakaiproject.scorm.dao.hibernate.AttemptDaoImpl">
-		<property name="sessionFactory">
-			<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
-		</property>
-	</bean>
-
-	<bean id="scorm.ContentPackageDaoTarget"
-		class="org.sakaiproject.scorm.dao.hibernate.ContentPackageDaoImpl">
-		<property name="sessionFactory">
-			<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
-		</property>
-	</bean>
-
-	<bean id="scorm.ContentPackageManifestDaoTarget"
-		class="org.sakaiproject.scorm.dao.hibernate.ContentPackageManifestDaoImpl">
-		<property name="sessionFactory">
-			<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
-		</property>
-	</bean>
-
-
-	<bean id="scorm.DataManagerDaoTarget"
-		class="org.sakaiproject.scorm.dao.hibernate.DataManagerDaoImpl">
-		<property name="sessionFactory">
-			<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
-		</property>
-	</bean>
-
 	<!-- This wraps our DAOs so that the transactions are managed -->
 	<bean id="org.sakaiproject.scorm.dao.api.ActivityTreeHolderDao"
 			class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="scorm.ActivityTreeHolderDaoTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.dao.hibernate.ActivityTreeHolderDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
+				</property>
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
@@ -55,7 +25,13 @@
 	<bean id="org.sakaiproject.scorm.dao.api.AttemptDao"
 			class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="scorm.AttemptDaoTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.dao.hibernate.AttemptDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
+				</property>
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
@@ -66,7 +42,13 @@
 	<bean id="org.sakaiproject.scorm.dao.api.ContentPackageDao"
 			class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="scorm.ContentPackageDaoTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.dao.hibernate.ContentPackageDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
+				</property>
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
@@ -77,7 +59,13 @@
 	<bean id="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao"
 			class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="scorm.ContentPackageManifestDaoTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.dao.hibernate.ContentPackageManifestDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
+				</property>
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
@@ -88,7 +76,13 @@
 	<bean id="org.sakaiproject.scorm.dao.api.DataManagerDao"
 			class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="scorm.DataManagerDaoTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.dao.hibernate.DataManagerDaoImpl">
+				<property name="sessionFactory">
+					<ref bean="org.sakaiproject.springframework.orm.hibernate.GlobalSessionFactory" />
+				</property>
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/adl/impl/spring-adl-services.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/adl/impl/spring-adl-services.xml
@@ -5,18 +5,18 @@
 
 	<bean id="org.sakaiproject.scorm.adl.ADLConsultant" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="org.sakaiproject.scorm.adl.ADLConsultantTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.adl.impl.ADLConsultantImpl">
+				<lookup-method name="contentPackageManifestDao" bean="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao" />
+				<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
+				<lookup-method name="activityTreeHolderDao" bean="org.sakaiproject.scorm.dao.api.ActivityTreeHolderDao" />
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
 			</props>
 		</property>
-	</bean>
-
-	<bean id="org.sakaiproject.scorm.adl.ADLConsultantTarget" class="org.sakaiproject.scorm.adl.impl.ADLConsultantImpl">
-		<lookup-method name="contentPackageManifestDao" bean="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao" />
-		<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
-		<lookup-method name="activityTreeHolderDao" bean="org.sakaiproject.scorm.dao.api.ActivityTreeHolderDao" />
 	</bean>
 
 	<bean id="org.sakaiproject.scorm.entity.ScormEntityProvider" class="org.sakaiproject.scorm.entity.ScormEntityProviderImpl">

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/ScormEntityProviderImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/entity/ScormEntityProviderImpl.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,8 @@ import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 
+import static org.sakaiproject.scorm.api.ScormConstants.SCORM_TOOL_ID;
+
 /**
  * Allows some basic functions on SCORM module instances via the EntityBroker.
  * 
@@ -70,9 +73,10 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 												PropertyProvideable, Resolvable, Outputable, RESTful, Redirectable, ActionsExecutable
 {
 	// Class members
-	private static final String TOOL_REG_NAME               = "sakai.scorm.tool";
-	private static final String SCORM_PLAYER_PAGE_URL_PART  = "wicket:bookmarkablePage=ScormPlayer:org.sakaiproject.scorm.ui.player.pages.ScormPlayerPage";
 	private static final String URL_CHARACTER_ENCODING      = "UTF-8";
+
+	// Full URL to module format: <domain><port>/portal/site/<siteID>/tool/<toolID>/scormPlayerPage?contentPackageId=<cpID>&resourceId=<rID>&title=<title>
+	private static final String URL_FORMAT = "%s/portal/site/%s/tool/%s/scormPlayerPage?contentPackageId=%s&resourceId=%s&title=%s";
 
 	// Instance members
 	private final ResourceLoader resourceLoader = new ResourceLoader( "messages" );
@@ -180,7 +184,7 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 
 						// Get the tool ID
 						String toolID = "";
-						Collection<ToolConfiguration> toolConfigs = site.getTools( TOOL_REG_NAME );
+						Collection<ToolConfiguration> toolConfigs = site.getTools( SCORM_TOOL_ID );
 						for( ToolConfiguration toolConfig : toolConfigs )
 						{
 							toolID = toolConfig.getId();
@@ -363,7 +367,7 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 		// Get the properties; if they're not null, get the named property requested
 		String property = null;
 		Map<String, String> properties = getProperties( reference );
-		if( properties != null && properties.containsKey( name ) )
+		if( properties != null )
 		{
 			property = properties.get( name );
 		}
@@ -464,13 +468,13 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 		}
 
 		// Return the generated HTML string
-		sb.append(  resourceLoader.getString( "htmlFooter" ) );
+		sb.append( resourceLoader.getString( "htmlFooter" ) );
 		return sb.toString();
 	}
 
 	/**
-	 * Generates the final URL for a SCORM module entity, which includes the tool ID,
-	 * content package ID, resource ID and title.
+	 * Generates the final URL for a SCORM module entity, which includes the site ID,
+	 * tool ID, content package ID, resource ID and title.
 	 *
 	 * @param entity the specific SCORM module the requester wants a link to
 	 * @return
@@ -480,13 +484,7 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 		log.debug( "generateFinalScormURL()" );
 
 		// Build and return the full URL to the specified SCORM module
-		String url = serverConfigurationService.getServerUrl() + "/portal/tool/" +
-					 entity.getToolID() + "?" +
-					 SCORM_PLAYER_PAGE_URL_PART + "&contentPackageId=" +
-					 entity.getContentPackageID() + "&resourceId=" +
-					 entity.getResourceID() + "&title=" +
-					 entity.getTitleEncoded();
-		return url;
+		return String.format(URL_FORMAT, serverConfigurationService.getServerUrl(), entity.getSiteID(), entity.getToolID(), entity.getContentPackageID(), entity.getResourceID(), entity.getTitleEncoded());
 	}
 
 	// *************************************************************
@@ -494,7 +492,7 @@ public class ScormEntityProviderImpl implements ScormEntityProvider, CoreEntityP
 	// *************************************************************
 
 	@Override public String     createEntity( EntityReference ref, Object entity, Map<String, Object> params )  { return null; }
-	@Override public List<?>    getEntities ( EntityReference ref, Search search )                              { return null; }
+	@Override public List<?>    getEntities ( EntityReference ref, Search search )                              { return Collections.emptyList(); }
 	@Override public String[]   getHandledInputFormats()                                                        { return null; }
 	@Override public void       updateEntity( EntityReference ref, Object entity, Map<String, Object> params )  {}
 	@Override public void       deleteEntity( EntityReference ref, Map<String, Object> params )                 {}

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/spring-scorm-services.xml
@@ -5,98 +5,76 @@
 
 	<bean id="org.sakaiproject.scorm.service.api.ScormApplicationService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="org.sakaiproject.scorm.service.api.ScormApplicationServiceTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.service.impl.ScormApplicationServiceImpl">
+				<lookup-method name="scormSequencingService" bean="org.sakaiproject.scorm.service.api.ScormSequencingService" />
+				<lookup-method name="adlManager" bean="org.sakaiproject.scorm.adl.ADLConsultant" />
+				<lookup-method name="attemptDao" bean="org.sakaiproject.scorm.dao.api.AttemptDao" />
+				<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
+				<lookup-method name="gradebookExternalAssessmentService" bean="org.sakaiproject.service.gradebook.GradebookExternalAssessmentService" />
+				<lookup-method name="learnerDao" bean="org.sakaiproject.scorm.dao.LearnerDao" />
+				<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
 			</props>
 		</property>
-	</bean>
-
-	<!-- This bean serves the Scorm API calls -->
-	<bean id="org.sakaiproject.scorm.service.api.ScormApplicationServiceTarget" class="org.sakaiproject.scorm.service.impl.ScormApplicationServiceImpl">
-
-		<!-- Scorm Sequencing Service to manage navigate calls -->
-		<lookup-method name="scormSequencingService" bean="org.sakaiproject.scorm.service.api.ScormSequencingService" />
-
-		<!-- Local utility bean -->
-		<lookup-method name="adlManager" bean="org.sakaiproject.scorm.adl.ADLConsultant" />
-
-		<!-- Data Access Objects -->
-		<lookup-method name="attemptDao" bean="org.sakaiproject.scorm.dao.api.AttemptDao" />
-		<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
-		<lookup-method name="gradebookExternalAssessmentService" bean="org.sakaiproject.service.gradebook.GradebookExternalAssessmentService" />
-		<lookup-method name="learnerDao" bean="org.sakaiproject.scorm.dao.LearnerDao" />
-		<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
 	</bean>
 
 	<bean id="org.sakaiproject.scorm.service.api.ScormResultService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="org.sakaiproject.scorm.service.api.ScormResultServiceTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.service.impl.ScormResultServiceImpl">
+				<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
+				<lookup-method name="attemptDao" bean="org.sakaiproject.scorm.dao.api.AttemptDao" />
+				<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
+				<lookup-method name="learnerDao" bean="org.sakaiproject.scorm.dao.LearnerDao" />
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
 			</props>
 		</property>
-	</bean>
-
-	<bean id="org.sakaiproject.scorm.service.api.ScormResultServiceTarget" class="org.sakaiproject.scorm.service.impl.ScormResultServiceImpl">
-
-		<!-- Service beans -->
-		<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
-
-		<!-- Data Access Objects -->
-		<lookup-method name="attemptDao" bean="org.sakaiproject.scorm.dao.api.AttemptDao" />
-		<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
-		<lookup-method name="learnerDao" bean="org.sakaiproject.scorm.dao.LearnerDao" />
 	</bean>
 
 	<bean id="org.sakaiproject.scorm.service.api.ScormContentService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="org.sakaiproject.scorm.service.api.ScormContentServiceTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.service.impl.ScormContentServiceImpl">
+				<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
+				<lookup-method name="resourceService" bean="org.sakaiproject.scorm.service.api.ScormResourceService" />
+				<lookup-method name="contentPackageDao" bean="org.sakaiproject.scorm.dao.api.ContentPackageDao" />
+				<lookup-method name="contentPackageManifestDao" bean="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao" />
+				<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
+				<lookup-method name="learnerDao" bean="org.sakaiproject.scorm.dao.LearnerDao" />
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
 			</props>
 		</property>
-	</bean>
-	
-	<!-- This bean manages content -->
-	<bean id="org.sakaiproject.scorm.service.api.ScormContentServiceTarget" class="org.sakaiproject.scorm.service.impl.ScormContentServiceImpl">
-		
-		<!-- Service beans -->
-		<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
-		<lookup-method name="resourceService" bean="org.sakaiproject.scorm.service.api.ScormResourceService" />
-		
-		<!-- Data Access Objects -->
-		<lookup-method name="contentPackageDao" bean="org.sakaiproject.scorm.dao.api.ContentPackageDao" />
-		<lookup-method name="contentPackageManifestDao" bean="org.sakaiproject.scorm.dao.api.ContentPackageManifestDao" />
-		<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
-		<lookup-method name="learnerDao" bean="org.sakaiproject.scorm.dao.LearnerDao" />
 	</bean>
 
 	<bean id="org.sakaiproject.scorm.service.api.ScormSequencingService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="org.sakaiproject.springframework.orm.hibernate.GlobalTransactionManager" />
-		<property name="target" ref="org.sakaiproject.scorm.service.api.ScormSequencingServiceTarget" />
+		<property name="target">
+			<bean class="org.sakaiproject.scorm.service.impl.ScormSequencingServiceImpl">
+				<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
+				<lookup-method name="scormContentService" bean="org.sakaiproject.scorm.service.api.ScormContentService" />
+				<lookup-method name="adlManager" bean="org.sakaiproject.scorm.adl.ADLConsultant" />
+				<lookup-method name="activityTreeHolderDao" bean="org.sakaiproject.scorm.dao.api.ActivityTreeHolderDao" />
+				<lookup-method name="attemptDao" bean="org.sakaiproject.scorm.dao.api.AttemptDao" />
+				<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
+			</bean>
+		</property>
 		<property name="transactionAttributes">
 			<props>
 				<prop key="*">PROPAGATION_REQUIRED</prop>
 			</props>
 		</property>
-	</bean>
-
-	<bean id="org.sakaiproject.scorm.service.api.ScormSequencingServiceTarget" class="org.sakaiproject.scorm.service.impl.ScormSequencingServiceImpl">
-		
-		<!-- Service beans -->
-		<lookup-method name="lms" bean="org.sakaiproject.scorm.service.api.LearningManagementSystem" />
-		<lookup-method name="scormContentService" bean="org.sakaiproject.scorm.service.api.ScormContentService" /> 
-		
-		<!-- Local utility bean -->
-		<lookup-method name="adlManager" bean="org.sakaiproject.scorm.adl.ADLConsultant" />
-		
-		<!-- Data Access Objects -->
-		<lookup-method name="activityTreeHolderDao" bean="org.sakaiproject.scorm.dao.api.ActivityTreeHolderDao" />
-		<lookup-method name="attemptDao" bean="org.sakaiproject.scorm.dao.api.AttemptDao" />
-		<lookup-method name="dataManagerDao" bean="org.sakaiproject.scorm.dao.api.DataManagerDao" />
 	</bean>
 </beans>

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiResourceService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiResourceService.java
@@ -54,13 +54,14 @@ import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.tool.api.ToolManager;
 import org.sakaiproject.util.Validator;
 
+import static org.sakaiproject.scorm.api.ScormConstants.ROOT_DIRECTORY;
+
 @Slf4j
 public abstract class SakaiResourceService extends AbstractResourceService
 {
 	private static final int MAXIMUM_ATTEMPTS_FOR_UNIQUENESS = 100;
 	private static final String FILE_UPLOAD_MAX_SIZE_CONFIG_KEY = "content.upload.max";
-	private static final String ROOT_DIRECTORY = "/private/scorm/";
-	private static final String ROOT_DIRECTORY_RESOURCE = "/content/private/scorm/";
+	private static final String ROOT_DIRECTORY_RESOURCE = "/content" + ROOT_DIRECTORY;
 
 	protected abstract ServerConfigurationService configurationService();
 	protected abstract ContentHostingService contentService();

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/ContentPackageResourceReference.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/ContentPackageResourceReference.java
@@ -22,17 +22,20 @@ import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.request.HttpHeaderCollection;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.resource.AbstractResource;
-import static org.apache.wicket.request.resource.AbstractResource.CONTENT_RANGE_ENDBYTE;
-import static org.apache.wicket.request.resource.AbstractResource.CONTENT_RANGE_STARTBYTE;
 import org.apache.wicket.request.resource.IResource;
 import org.apache.wicket.request.resource.PartWriterCallback;
 import org.apache.wicket.request.resource.ResourceReference;
 import org.apache.wicket.util.resource.IResourceStream;
+
 import org.sakaiproject.scorm.service.sakai.impl.ContentPackageSakaiResource;
 import org.sakaiproject.scorm.ui.player.util.CompressingContentPackageResourceStream;
-
 import org.sakaiproject.scorm.ui.player.util.ContentPackageWebResource;
 import org.sakaiproject.scorm.ui.player.util.ContentPackageWebResource.WicketContentPackageWebResource;
+
+import static org.apache.wicket.request.resource.AbstractResource.CONTENT_RANGE_ENDBYTE;
+import static org.apache.wicket.request.resource.AbstractResource.CONTENT_RANGE_STARTBYTE;
+
+import static org.sakaiproject.scorm.api.ScormConstants.ROOT_DIRECTORY;
 
 /**
  *
@@ -57,7 +60,7 @@ public class ContentPackageResourceReference extends ResourceReference
         @Override
         protected ResourceResponse newResourceResponse( Attributes attributes )
         {
-            StringBuilder b = new StringBuilder( "/private/scorm/" + attributes.getParameters().get( "resourceID" ).toString() + "/" + attributes.getParameters().get( "resourceName" ).toString() );
+            StringBuilder b = new StringBuilder( ROOT_DIRECTORY + attributes.getParameters().get( "resourceID" ).toString() + "/" + attributes.getParameters().get( "resourceName" ).toString() );
             for( int i = 0; i < attributes.getParameters().getIndexedCount(); i++ )
             {
                 if (attributes.getParameters().get( i ).toString().equals( "contentpackages"))


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-166

Entity linking no longer works in 20.x. When selecting 'browse server', the SCORM tool doesn't show up at all.

This is due to the switch in core Sakai from the EntityLinker to the elfinder plugin for CKEditor, and as such now requires code to be added to core Sakai.

There are also a few small changes to the SCORM entity provider due to the Wicket 8 upgrade in SCO-117.