### PR TITLE
SCO-168: improve over quota message to include defined quota

### DIFF
--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormResourceService.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormResourceService.java
@@ -17,6 +17,13 @@ package org.sakaiproject.scorm.service.api;
 
 import java.io.InputStream;
 import java.util.List;
+import org.sakaiproject.exception.IdInvalidException;
+import org.sakaiproject.exception.IdLengthException;
+import org.sakaiproject.exception.IdUniquenessException;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.OverQuotaException;
+import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.exception.ServerOverloadException;
 
 import org.sakaiproject.scorm.exceptions.InvalidArchiveException;
 import org.sakaiproject.scorm.exceptions.ResourceNotDeletedException;
@@ -40,7 +47,8 @@ public interface ScormResourceService
 
 	public List<Archive> getUnvalidatedArchives() throws ResourceStorageException;
 
-	public String putArchive(InputStream stream, String name, String mimeType, boolean isHidden, int priority) throws ResourceStorageException;
+	public String putArchive(InputStream stream, String name, String mimeType, boolean isHidden, int priority) throws PermissionException, IdUniquenessException, IdLengthException,
+                                                                                                                IdInvalidException, IdUnusedException, OverQuotaException, ServerOverloadException;
 
 	public void removeResources(String collectionId) throws ResourceNotDeletedException;
 }

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiResourceService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/SakaiResourceService.java
@@ -38,9 +38,13 @@ import org.sakaiproject.content.api.ContentResourceEdit;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.entity.api.ResourcePropertiesEdit;
 import org.sakaiproject.event.api.NotificationService;
+import org.sakaiproject.exception.IdInvalidException;
+import org.sakaiproject.exception.IdLengthException;
+import org.sakaiproject.exception.IdUniquenessException;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.IdUsedException;
 import org.sakaiproject.exception.InUseException;
+import org.sakaiproject.exception.OverQuotaException;
 import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.exception.ServerOverloadException;
 import org.sakaiproject.exception.TypeException;
@@ -553,7 +557,8 @@ public abstract class SakaiResourceService extends AbstractResourceService
 	}
 
 	@Override
-	public String putArchive(InputStream stream, String name, String mimeType, boolean isHidden, int priority) throws ResourceStorageException
+	public String putArchive(InputStream stream, String name, String mimeType, boolean isHidden, int priority) throws PermissionException, IdUniquenessException, IdLengthException,
+                                                                                                                IdInvalidException, IdUnusedException, OverQuotaException, ServerOverloadException
 	{
 		String collectionId = getRootDirectoryPath();
 		String fileName = name;
@@ -587,7 +592,7 @@ public abstract class SakaiResourceService extends AbstractResourceService
 				log.error("Failed to place resources in Sakai content repository", e);
 			}
 
-			throw new ResourceStorageException(e);
+			throw e;
 		}
 	}
 

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/UploadPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/upload/UploadPage.properties
@@ -16,7 +16,7 @@ upload.IdUnusedException = There is a problem with the resources collection or i
 upload.IdUniquenessException = A resource of this name already exists under the same collection.
 upload.IdLengthException = The resource name provided is too long.
 upload.IdInvalidException = The resource name provided is not valid.
-upload.OverQuotaException = You have exceeded your quota or there is no more space remaining for this resource.
+upload.OverQuotaException = You have exceeded your quota of {0} megabytes, or there is no more space remaining for this resource.
 upload.PermissionException = You do not have permission to add this resource at this time.
 
 validate.no.file = No Content Package was selected, or an invalid path was provided.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-168

In the situation where a user attempts to upload a module which isn't too big (less than the max file size allowed), but puts the user over their defined quota, an error message is presented to the user indicating that they're over the quota. Lets improve this message to include the value of what their quota actually is.