### PR TITLE
SCO-175 fix build for master (22.x)

### DIFF
--- a/scorm-impl/client/pom.xml
+++ b/scorm-impl/client/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/scorm-impl/content/pom.xml
+++ b/scorm-impl/content/pom.xml
@@ -58,6 +58,7 @@
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>net.sf.ehcache</groupId>

--- a/scorm-impl/service/pom.xml
+++ b/scorm-impl/service/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -82,10 +83,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.sakaiproject.kernel</groupId>
-            <artifactId>sakai-component-manager</artifactId>
         </dependency>
     </dependencies>
 

--- a/scorm-tool/pom.xml
+++ b/scorm-tool/pom.xml
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-175

> [ERROR] [ERROR] Some problems were encountered while processing the POMs:
> [ERROR] 'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 54, column 21
> [ERROR] 'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 58, column 21
> [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.sakaiproject.kernel:sakai-component-manager:jar -> duplicate declaration of version (?) @ line 86, column 21
> [ERROR] 'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 74, column 21
> [ERROR] 'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 90, column 21
>  @ 
> [ERROR] The build could not read 4 projects -> [Help 1]
> [ERROR]   
> [ERROR]   The project org.sakaiproject.scorm:scorm-client-impl:22-SNAPSHOT (/opt/src/git/sakai/contrib/SCORM.2004.3ED.RTE/scorm-impl/client/pom.xml) has 1 error
> [ERROR]     'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 54, column 21
> [ERROR]   
> [ERROR]   The project org.sakaiproject.scorm:scorm-content-impl:22-SNAPSHOT (/opt/src/git/sakai/contrib/SCORM.2004.3ED.RTE/scorm-impl/content/pom.xml) has 1 error
> [ERROR]     'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 58, column 21
> [ERROR]   
> [ERROR]   The project org.sakaiproject.scorm:scorm-service-impl:22-SNAPSHOT (/opt/src/git/sakai/contrib/SCORM.2004.3ED.RTE/scorm-impl/service/pom.xml) has 1 error
> [ERROR]     'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 74, column 21
> [ERROR]   
> [ERROR]   The project org.sakaiproject.scorm:scorm-tool:22-SNAPSHOT (/opt/src/git/sakai/contrib/SCORM.2004.3ED.RTE/scorm-tool/pom.xml) has 1 error
> [ERROR]     'dependencies.dependency.version' for javax.activation:javax.activation-api:jar is missing. @ line 90, column 21