### PR TITLE
SCO-176 fix build for 20.x

### DIFF
--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/MockServerConfigurationService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/MockServerConfigurationService.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 import org.sakaiproject.component.api.ServerConfigurationService;
 
@@ -34,12 +33,6 @@ public class MockServerConfigurationService implements ServerConfigurationServic
 
     @Override
     public List<String> getCategoryGroups( String category )
-    {
-        throw new UnsupportedOperationException( "Not supported yet." );
-    }
-
-    @Override
-    public Set<String> getCommaSeparatedListAsSet( String string )
     {
         throw new UnsupportedOperationException( "Not supported yet." );
     }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-176

Build failure:

> [ERROR] /opt/src/git/sakai/contrib/SCORM.2004.3ED.RTE/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/MockServerConfigurationService.java:[41,5] method does not override or implement a method from a supertype