### PR TITLE
SCO-177 configure > date pickers don't appear

### DIFF
--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/datepicker/SakaiDateTimeField.java
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/datepicker/SakaiDateTimeField.java
@@ -88,7 +88,7 @@ public class SakaiDateTimeField extends TextField<ZonedDateTime>
 		setOutputMarkupId(true);
 		dateConverter = new SakaiIsoDateConverter(getMarkupId());
 
-		add(AttributeModifier.append("class", "form-control datepicker sakai-datetimefield"));
+		add(AttributeModifier.append("class", "sakai-datetimefield"));
 	}
 
 	@Override

--- a/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/datepicker/res/SakaiDateTimeField.js
+++ b/wicket-tool/src/java/org/sakaiproject/wicket/markup/html/datepicker/res/SakaiDateTimeField.js
@@ -1,5 +1,12 @@
 function loadJQueryDatePicker(inputField, allowEmptyDate, value)
 {
+    if (typeof $.fn.button.noConflict === typeof Function)
+    {
+        // bootstrap has taken over the button() function, assign it back to jquery ui
+        // to resolve conflicts with the timepicker plugin
+        $.fn.button.noConflict();
+    }
+
     localDatePicker(
     {
         input: '#' + inputField,


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-177

Date pickers don't appear when editing a module config. There is an error in the javascript console:

> Uncaught TypeError: i.options is undefined
>     jQuery 24
>     sliderAccess lang-datepicker.js:1414
>     jQuery 2
>     sliderAccess lang-datepicker.js:1414
>     _injectTimePicker lang-datepicker.js:1419
>     _addTimePicker lang-datepicker.js:1419
>     _updateDatepicker lang-datepicker.js:1419
>     jQuery 4
> jquery-ui.min.js:8:11119