### PR TITLE
SCO-178 configure > push existing grades to gradebook

### DIFF
--- a/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormApplicationService.java
+++ b/scorm-api/src/java/org/sakaiproject/scorm/service/api/ScormApplicationService.java
@@ -15,6 +15,9 @@
  */
 package org.sakaiproject.scorm.service.api;
 
+import org.sakaiproject.scorm.model.api.Attempt;
+import org.sakaiproject.scorm.model.api.ContentPackage;
+import org.sakaiproject.scorm.model.api.LearnerExperience;
 import org.sakaiproject.scorm.model.api.ScoBean;
 import org.sakaiproject.scorm.model.api.SessionBean;
 import org.sakaiproject.scorm.navigation.INavigable;
@@ -43,4 +46,8 @@ public interface ScormApplicationService
 	public boolean setValue(String dataModelElement, String value, SessionBean sessionBean, ScoBean scoBean);
 
 	public boolean terminate(String iParam, INavigationEvent navigationEvent, SessionBean sessionBean, ScoBean scoBean);
+
+	public void synchResultWithGradebook(LearnerExperience experience, ContentPackage contentPackage, String itemIdentifier, Attempt latestAttempt);
+
+	public void synchResultWithGradebook(SessionBean sessionBean);
 }

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/impl/ScormApplicationServiceImpl.java
@@ -54,7 +54,9 @@ import org.sakaiproject.scorm.dao.api.DataManagerDao;
 import org.sakaiproject.scorm.exceptions.LearnerNotDefinedException;
 import org.sakaiproject.scorm.model.api.ActivityTreeHolder;
 import org.sakaiproject.scorm.model.api.Attempt;
+import org.sakaiproject.scorm.model.api.ContentPackage;
 import org.sakaiproject.scorm.model.api.Learner;
+import org.sakaiproject.scorm.model.api.LearnerExperience;
 import org.sakaiproject.scorm.model.api.ScoBean;
 import org.sakaiproject.scorm.model.api.ScoBeanImpl;
 import org.sakaiproject.scorm.model.api.SessionBean;
@@ -1195,7 +1197,15 @@ public abstract class ScormApplicationServiceImpl implements ScormApplicationSer
 		return isSuccessful;
 	}
 
-	protected void synchResultWithGradebook(SessionBean sessionBean)
+	public void synchResultWithGradebook(LearnerExperience experience, ContentPackage contentPackage, String itemIdentifier, Attempt latestAttempt)
+	{
+		SessionBean sessionBean = new SessionBean(experience.getLearnerId(), contentPackage);
+		ScoBean scoBean = produceScoBean(itemIdentifier, sessionBean);
+		scoBean.setDataManagerId(latestAttempt.getDataManagerId(scoBean.getScoId()));
+		synchResultWithGradebook(sessionBean);
+	}
+
+	public void synchResultWithGradebook(SessionBean sessionBean)
 	{
 		ScoBean displayingSco = sessionBean.getDisplayingSco();
 		IDataManager dataManager = getDataManager(displayingSco);

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
@@ -16,6 +16,7 @@
 package org.sakaiproject.scorm.ui.console.pages;
 
 import java.io.Serializable;
+import java.text.MessageFormat;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,10 +44,14 @@ import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import org.sakaiproject.scorm.dao.api.ContentPackageManifestDao;
+import org.sakaiproject.scorm.model.api.Attempt;
 import org.sakaiproject.scorm.model.api.ContentPackage;
 import org.sakaiproject.scorm.model.api.ContentPackageManifest;
+import org.sakaiproject.scorm.model.api.LearnerExperience;
 import org.sakaiproject.scorm.service.api.LearningManagementSystem;
+import org.sakaiproject.scorm.service.api.ScormApplicationService;
 import org.sakaiproject.scorm.service.api.ScormContentService;
+import org.sakaiproject.scorm.service.api.ScormResultService;
 import org.sakaiproject.service.gradebook.shared.AssessmentNotFoundException;
 import org.sakaiproject.service.gradebook.shared.AssignmentHasIllegalPointsException;
 import org.sakaiproject.service.gradebook.shared.ConflictingAssignmentNameException;
@@ -165,6 +170,12 @@ public class PackageConfigurationPage extends ConsoleBasePage
 
 	@SpringBean(name = "org.sakaiproject.tool.api.ToolManager")
 	ToolManager toolManager;
+
+	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormResultService")
+	ScormResultService resultService;
+
+	@SpringBean(name="org.sakaiproject.scorm.service.api.ScormApplicationService")
+	ScormApplicationService applicationService;
 
 	private String unlimitedMessage;
 
@@ -295,6 +306,18 @@ public class PackageConfigurationPage extends ConsoleBasePage
 							{
 								gradebookExternalAssessmentService.addExternalAssessment(context, assessmentExternalId, null, assessmentSetup.getItemTitle(), assessmentSetup.numberOffPoints,
 																							gradebookSetup.getContentPackage().getDueOn(), "SCORM player", null, false);
+
+								// Push grades on creation of gradebook item
+								ContentPackage contentPackage = contentService.getContentPackage(contentPackageId);
+								List<LearnerExperience> learnerExperiences = resultService.getLearnerExperiences(contentPackageId);
+								for (LearnerExperience experience : learnerExperiences)
+								{
+									Attempt latestAttempt = resultService.getNewstAttempt(contentPackageId, experience.getLearnerId());
+									if (latestAttempt != null)
+									{
+										applicationService.synchResultWithGradebook(experience, contentPackage, assessmentSetup.getLaunchData().getItemIdentifier(), latestAttempt);
+									}
+								}
 							}
 							else if (has && !on)
 							{
@@ -319,6 +342,11 @@ public class PackageConfigurationPage extends ConsoleBasePage
 						catch (AssignmentHasIllegalPointsException ex)
 						{
 							error(getLocalizer().getString("form.error.gradebook.noGradebook", this));
+							onError(target);
+						}
+						catch (Exception ex)
+						{
+							error(MessageFormat.format("form.error.unknown", ex.getMessage()));
 							onError(target);
 						}
 					}

--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
@@ -24,10 +24,11 @@ form.error.gradebook.noGradebook = A Gradebook connection cannot be made for thi
 form.error.gradebook.assessmentNotFound = The corresponding Gradebook item could not be located. Please try again.
 form.error.gradebook.conflictingName = A Gradebook item with this name already exists. Please edit the name below and try again.
 form.error.gradebook.invalidPoints = The total point value of this module is incompatible with the Gradebook.
+form.error.unknown = An unknown error has occurred: {0}
 
 page.title = Configure Content Package
 page.update = Update
 
 unlimited = Unlimited
 
-verify.synchronizeWithGradebook = Are you sure you want to remove the Gradebook connection for this sub-module? All grades associated with this sub-module will be deleted.
+verify.synchronizeWithGradebook = Are you sure you want to remove the Gradebook integration for this sub-module? All of the grades associated with this sub-module will be removed from the Gradebook.


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-178

Unlike Assignments and Samigo, when you remove gradebook itegration and then re-enable it, it does not push existing scores to the Gradebook. It only seems to happen when a user completes a module.

Change this so that when gradebook integration is selected, it will scan for existing completed user attempts, and push any grades from them to the gradebook automatically.

*NOTE:* in order for SCORM to push a grade to the gradebook, the following conditions must be met:

* `mode` = "normal"
* `credit` = "credit"
* `completionStatus` == "completed"

In order to meet the last requirement, the attempt must meet the passing grade criteria. For example, if your SCORM module has a passing criteria of 75/100 (made up of 4 equally weighted questions worth 25 each), you must get at least 3 out of 4 questions correct in order for the grade to be pushed to the gradebook. If you don't get at least 75/100, the `completionStatus` remains at "incomplete", and the grade will not be pushed.

*NOTE:* SCORM modules which allow multiple attempts do not have any sort of "scoring type" like Samigo does. In effect, all subsequent attempts will over-write the grade in the Gradebook regardless if it is higher or lower than the previously recorded score (also provided that the new attempt meets the conditional requirements mentioned in my previous comment).

This behaviour affects how we will implement the desired behaviour described in this ticket:

* If multiple attempts exist, upon saving gradebook integration it will push the most recent (latest) attempt's grade to the gradebook. It will not perform any logic to find the highest attempt grade, because SCORM Player has no notion of "scoring types"