### PR TITLE
SCO-179 gradebook integration silently fails for 2nd module of same name

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.java
@@ -284,7 +284,7 @@ public class PackageConfigurationPage extends ConsoleBasePage
 					onError(target);
 				}
 
-				// Only continue to update/save if there are no validation errors
+				// Validation round 2 - gradebook set up; only do this if there were no validation errors already thrown, and gradebook exists in the site
 				if (!feedback.anyErrorMessage() && gradebookSetup.isGradebookDefined())
 				{
 					String context = getContext();
@@ -294,17 +294,18 @@ public class PackageConfigurationPage extends ConsoleBasePage
 						boolean on = assessmentSetup.isSynchronizeSCOWithGradebook();
 						String assessmentExternalId = getAssessmentExternalId(gradebookSetup, assessmentSetup);
 						boolean has = gradebookExternalAssessmentService.isExternalAssignmentDefined(context, assessmentExternalId);
+						String fixedTitle = getItemTitle(assessmentSetup, context);
 
 						try
 						{
 							if (has && on)
 							{
-								gradebookExternalAssessmentService.updateExternalAssessment(context, assessmentExternalId, null, null, assessmentSetup.getItemTitle(), assessmentSetup.numberOffPoints,
+								gradebookExternalAssessmentService.updateExternalAssessment(context, assessmentExternalId, null, null, fixedTitle, assessmentSetup.numberOffPoints,
 																							gradebookSetup.getContentPackage().getDueOn(), false);
 							}
 							else if (!has && on)
 							{
-								gradebookExternalAssessmentService.addExternalAssessment(context, assessmentExternalId, null, assessmentSetup.getItemTitle(), assessmentSetup.numberOffPoints,
+								gradebookExternalAssessmentService.addExternalAssessment(context, assessmentExternalId, null, fixedTitle, assessmentSetup.numberOffPoints,
 																							gradebookSetup.getContentPackage().getDueOn(), "SCORM player", null, false);
 
 								// Push grades on creation of gradebook item
@@ -336,6 +337,7 @@ public class PackageConfigurationPage extends ConsoleBasePage
 						}
 						catch (ConflictingAssignmentNameException ex)
 						{
+							// This should never occur with the re-introduction and use of getItemTitle(), but we'll keep it here for posterity
 							error(getLocalizer().getString("form.error.gradebook.conflictingName", this));
 							onError(target);
 						}
@@ -350,7 +352,11 @@ public class PackageConfigurationPage extends ConsoleBasePage
 							onError(target);
 						}
 					}
+				}
 
+				// Only save & navigate back to the landing page if there were no errors
+				if (!feedback.anyErrorMessage())
+				{
 					contentService.updateContentPackage(contentPackage);
 					setResponsePage(pageSubmit);
 				}
@@ -405,5 +411,17 @@ public class PackageConfigurationPage extends ConsoleBasePage
 	{
 		String assessmentExternalId = "" + gradebook.getContentPackageId() + ":" + assessment.getLaunchData().getItemIdentifier();
 		return assessmentExternalId;
+	}
+
+	private String getItemTitle(AssessmentSetup assessmentSetup, String context)
+	{
+		String fixedTitle = assessmentSetup.getItemTitle();
+		int count = 1;
+		while (gradebookExternalAssessmentService.isAssignmentDefined(context, fixedTitle))
+		{
+			fixedTitle = assessmentSetup.getItemTitle() + " (" + count++ + ")";
+		}
+
+		return fixedTitle;
 	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-179

Steps to reproduce:

1. Upload a module to the same site twice
2. Notice the 2nd one gets appended with " (2)" in the package list
3. Configure the 1st one to send grades to the gradebook
4. Observe: the gradebook item is created
5. Configure the 2nd one to send grades to the gradebook
6. Observe: the operation appears as thought it was successful (no error message), but the gradebook item was not created

During the Wicket 8 upgrade I changed how this worked, but made a false assumption that it was using the SCORM module's top level title as the Gradebook item name. However, because each SCORM module can have multiple "chapters" or "sections", and each one can have it's own gradebook item, my assumption has the following problems:

* there is an exception being thrown that tells them to alter the main title
** it isn't being shown because of a logic error
** even if it was shown, it would tell them to alter the title, which has zero effect on what the gradebook item name is (it's taken from the chapter/section name, not the SCORM module's title)
* the individual chapter/section names are not user editable; they are hard coded in the module itself

So, instead of catching this exception and reporting it to the user, we have to do what it was originally doing: just append some number to make the Gradebook item name unique.