### PR TITLE
SCO-180 clarify player option language

### DIFF
--- a/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
+++ b/scorm-tool/src/java/org/sakaiproject/scorm/ui/console/pages/PackageConfigurationPage.properties
@@ -9,8 +9,8 @@ form.label.last.changed.on            = Last Changed On:
 form.label.number.of.tries            = Number Of Attempts Allowed
 form.label.open.date                  = Open Date
 form.label.package.name               = Content Package Name
-form.label.show.toc                   = Show Content Package Structure in Player
-form.label.show.navBar                = Show Player Controls (e.g. Start, Next, Back, Suspend, Quit buttons)
+form.label.show.toc                   = Show Content Package Structure in SCORM Player
+form.label.show.navBar                = Show SCORM Player Controls (e.g. Start, Next, Back, Suspend, Quit buttons)
 
 form.heading.availability = Availability
 form.heading.displayOptions = Display Options


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SCO-180

There has been some confusion in the past about whether or not these settings apply to Sakai, or to the SCORM Player pop-up window itself. It's trivial to add more context to these messages for clarification.