### PR TITLE
Fix Github Actions build, remove bad xml-apis dependency, and fix MockSiteService

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,19 +5,19 @@ name: Java CI with Maven
 
 on:
   pull_request:
-    branches: [ master, 20.x, 21.x, 22.x, 23.x ]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-          architecture: x64
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Build with Maven
         env:
           MAVEN_OPTS: -Djava.awt.headless=true -Dorg.slf4j.simpleLogger.defaultLogLevel=info -Dmaven.wagon.http.retryHandler.count=2 -Dmaven.wagon.http.pool=true

--- a/scorm-impl/pack/pom.xml
+++ b/scorm-impl/pack/pom.xml
@@ -63,12 +63,6 @@
             <artifactId>xmlParserAPIs</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-            <type>jar</type>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build />

--- a/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/mocks/MockSiteService.java
+++ b/scorm-impl/service/src/java/org/sakaiproject/scorm/service/sakai/impl/mocks/MockSiteService.java
@@ -643,4 +643,9 @@ public class MockSiteService implements SiteService
     {
         return SiteService.super.willArchiveMerge();
     }
+
+    @Override
+    public String idFromSiteReference(String ref) {
+        throw new UnsupportedOperationException( "Not supported yet." );
+    }
 }


### PR DESCRIPTION
After merging into master, 23.x needs fixed Mocks to build